### PR TITLE
RFC: Deepen connection lifecycle behind a single ConnectionManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [1.23.3](https://github.com/terebentina/mongo-buddy/compare/v1.23.2...v1.23.3) (2026-04-16)
+
+
+### Bug Fixes
+
+* **preload:** sync MongoApi type declaration with runtime API ([dd67cfa](https://github.com/terebentina/mongo-buddy/commit/dd67cfa573a4b38655b8e702c54e446ad30005e0))
+* **table:** use unique React keys for document rows ([566f334](https://github.com/terebentina/mongo-buddy/commit/566f334effedeb7d7e2f4e55e84c1a22dfc80624))
+
 ## [1.23.2](https://github.com/terebentina/mongo-buddy/compare/v1.23.1...v1.23.2) (2026-04-15)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongo-buddy",
-  "version": "1.23.2",
+  "version": "1.23.3",
   "description": "Lightweight MongoDB GUI client",
   "author": "Dan Caragea",
   "type": "module",

--- a/src/main/connection-manager.test.ts
+++ b/src/main/connection-manager.test.ts
@@ -1,0 +1,375 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { MongoClient } from 'mongodb';
+import {
+  createConnectionManager,
+  type ConnectionManager,
+  type ConnectionState,
+  type ConnectionStorePort,
+  type HistoryStorePort,
+  type MongoClientFactoryPort,
+} from './connection-manager';
+import type { QueryHistoryEntry } from '../shared/types';
+
+interface FakeClient {
+  connect: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+  db: ReturnType<typeof vi.fn>;
+}
+
+function makeFakeClient(
+  opts: {
+    connectImpl?: () => Promise<void>;
+    listDatabasesImpl?: () => Promise<{ databases: Array<{ name: string; sizeOnDisk?: number; empty?: boolean }> }>;
+    listCollectionsImpl?: (db: string) => Array<{ name: string; type?: string }>;
+    estimatedCountImpl?: (db: string, coll: string) => Promise<number>;
+  } = {}
+): FakeClient {
+  const listDbs = opts.listDatabasesImpl ?? (async () => ({ databases: [] }));
+  const listColls = opts.listCollectionsImpl ?? (() => []);
+  const count = opts.estimatedCountImpl ?? (async () => 0);
+
+  return {
+    connect: vi.fn(opts.connectImpl ?? (async () => {})),
+    close: vi.fn(async () => {}),
+    db: vi.fn((dbName?: string) => ({
+      admin: () => ({ listDatabases: listDbs }),
+      listCollections: () => ({ toArray: async () => listColls(dbName ?? '') }),
+      collection: (collName: string) => ({
+        estimatedDocumentCount: () => count(dbName ?? '', collName),
+      }),
+    })),
+  };
+}
+
+function makeDeps(
+  overrides: {
+    client?: FakeClient;
+    setLastUsed?: ConnectionStorePort['setLastUsed'];
+    getAll?: HistoryStorePort['getAll'];
+    connectionKeyFromUri?: (uri: string) => string;
+    factoryCreate?: MongoClientFactoryPort['create'];
+  } = {}
+): {
+  deps: Parameters<typeof createConnectionManager>[0];
+  client: FakeClient;
+  setLastUsed: ReturnType<typeof vi.fn>;
+  getAll: ReturnType<typeof vi.fn>;
+  clientFactory: MongoClientFactoryPort;
+} {
+  const client = overrides.client ?? makeFakeClient();
+  const setLastUsed = vi.fn(overrides.setLastUsed ?? (() => {}));
+  const getAll = vi.fn(overrides.getAll ?? (() => [] as QueryHistoryEntry[]));
+  const clientFactory: MongoClientFactoryPort = {
+    create: overrides.factoryCreate ?? vi.fn(() => client as unknown as MongoClient),
+  };
+  return {
+    deps: {
+      clientFactory,
+      connectionStore: { setLastUsed },
+      historyStore: { getAll },
+      connectionKeyFromUri: overrides.connectionKeyFromUri ?? ((uri: string) => `key:${uri}`),
+    },
+    client,
+    setLastUsed,
+    getAll,
+    clientFactory,
+  };
+}
+
+describe('ConnectionManager', () => {
+  let mgr: ConnectionManager;
+
+  describe('happy path (single-db cluster)', () => {
+    beforeEach(() => {
+      const client = makeFakeClient({
+        listDatabasesImpl: async () => ({
+          databases: [{ name: 'mydb', sizeOnDisk: 1024, empty: false }],
+        }),
+        listCollectionsImpl: () => [
+          { name: 'users', type: 'collection' },
+          { name: 'orders', type: 'collection' },
+        ],
+        estimatedCountImpl: async (_db, coll) => (coll === 'users' ? 10 : 20),
+      });
+      const history: QueryHistoryEntry[] = [
+        { id: 'h1', type: 'filter', query: '{}', db: 'mydb', collection: 'users', timestamp: 1 },
+      ];
+      const built = makeDeps({ client, getAll: () => history });
+      mgr = createConnectionManager(built.deps);
+    });
+
+    it('returns full ConnectedSession with autoSelectedDb and collections', async () => {
+      const result = await mgr.connect('mongodb://localhost/');
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data).toEqual({
+        uri: 'mongodb://localhost/',
+        connectionKey: 'key:mongodb://localhost/',
+        databases: [{ name: 'mydb', sizeOnDisk: 1024, empty: false }],
+        queryHistory: [{ id: 'h1', type: 'filter', query: '{}', db: 'mydb', collection: 'users', timestamp: 1 }],
+        autoSelectedDb: 'mydb',
+        collections: [
+          { name: 'users', type: 'collection', count: 10 },
+          { name: 'orders', type: 'collection', count: 20 },
+        ],
+      });
+    });
+
+    it('transitions state connecting → connected', async () => {
+      const states: ConnectionState[] = [];
+      mgr.onStateChange((s) => states.push(s));
+      await mgr.connect('mongodb://localhost/');
+      expect(states.map((s) => s.status)).toEqual(['connecting', 'connected']);
+      expect(states[1]).toMatchObject({
+        status: 'connected',
+        uri: 'mongodb://localhost/',
+        connectionKey: 'key:mongodb://localhost/',
+      });
+    });
+  });
+
+  describe('multi-db cluster', () => {
+    it('returns autoSelectedDb null and collections empty', async () => {
+      const client = makeFakeClient({
+        listDatabasesImpl: async () => ({
+          databases: [
+            { name: 'db1', sizeOnDisk: 1, empty: false },
+            { name: 'db2', sizeOnDisk: 2, empty: false },
+          ],
+        }),
+      });
+      mgr = createConnectionManager(makeDeps({ client }).deps);
+
+      const result = await mgr.connect('mongodb://localhost/');
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.autoSelectedDb).toBeNull();
+      expect(result.data.collections).toEqual([]);
+      expect(client.db).not.toHaveBeenCalledWith('db1');
+      expect(client.db).not.toHaveBeenCalledWith('db2');
+    });
+  });
+
+  describe('rollback on failure', () => {
+    it('client.connect fails → state disconnected, close NOT called, setLastUsed NOT called', async () => {
+      const client = makeFakeClient({
+        connectImpl: async () => {
+          throw new Error('refused');
+        },
+      });
+      const built = makeDeps({ client });
+      mgr = createConnectionManager(built.deps);
+
+      const result = await mgr.connect('mongodb://bad/');
+      expect(result).toEqual({ ok: false, error: 'refused' });
+      expect(mgr.getState()).toEqual({ status: 'disconnected' });
+      expect(client.close).not.toHaveBeenCalled();
+      expect(built.setLastUsed).not.toHaveBeenCalled();
+    });
+
+    it('listDatabases fails → close called once, state disconnected', async () => {
+      const client = makeFakeClient({
+        listDatabasesImpl: async () => {
+          throw new Error('no auth');
+        },
+      });
+      const built = makeDeps({ client });
+      mgr = createConnectionManager(built.deps);
+
+      const result = await mgr.connect('mongodb://bad/');
+      expect(result).toEqual({ ok: false, error: 'no auth' });
+      expect(mgr.getState()).toEqual({ status: 'disconnected' });
+      expect(client.close).toHaveBeenCalledTimes(1);
+      expect(built.setLastUsed).not.toHaveBeenCalled();
+    });
+
+    it('listCollections fails (single-db path) → close called once, state disconnected', async () => {
+      const client = makeFakeClient({
+        listDatabasesImpl: async () => ({ databases: [{ name: 'mydb' }] }),
+        listCollectionsImpl: () => {
+          throw new Error('boom');
+        },
+      });
+      const built = makeDeps({ client });
+      mgr = createConnectionManager(built.deps);
+
+      const result = await mgr.connect('mongodb://bad/');
+      expect(result.ok).toBe(false);
+      expect(mgr.getState()).toEqual({ status: 'disconnected' });
+      expect(client.close).toHaveBeenCalledTimes(1);
+    });
+
+    it('historyStore.getAll fails → close called once, state disconnected', async () => {
+      const client = makeFakeClient({
+        listDatabasesImpl: async () => ({ databases: [{ name: 'db1' }, { name: 'db2' }] }),
+      });
+      const built = makeDeps({
+        client,
+        getAll: () => {
+          throw new Error('disk');
+        },
+      });
+      mgr = createConnectionManager(built.deps);
+
+      const result = await mgr.connect('mongodb://bad/');
+      expect(result.ok).toBe(false);
+      expect(mgr.getState()).toEqual({ status: 'disconnected' });
+      expect(client.close).toHaveBeenCalledTimes(1);
+    });
+
+    it('onStateChange fires connecting → disconnected on failure', async () => {
+      const client = makeFakeClient({
+        connectImpl: async () => {
+          throw new Error('nope');
+        },
+      });
+      mgr = createConnectionManager(makeDeps({ client }).deps);
+      const states: ConnectionState[] = [];
+      mgr.onStateChange((s) => states.push(s));
+      await mgr.connect('mongodb://bad/');
+      expect(states.map((s) => s.status)).toEqual(['connecting', 'disconnected']);
+    });
+  });
+
+  describe('connection key lifecycle', () => {
+    it('getConnectionKey is null before connect, set after, null after disconnect', async () => {
+      const client = makeFakeClient({
+        listDatabasesImpl: async () => ({ databases: [{ name: 'db1' }, { name: 'db2' }] }),
+      });
+      mgr = createConnectionManager(makeDeps({ client, connectionKeyFromUri: (uri) => new URL(uri).host }).deps);
+
+      expect(mgr.getConnectionKey()).toBeNull();
+
+      await mgr.connect('mongodb://localhost:27017/');
+      expect(mgr.getConnectionKey()).toBe('localhost:27017');
+
+      await mgr.disconnect();
+      expect(mgr.getConnectionKey()).toBeNull();
+      expect(mgr.getState()).toEqual({ status: 'disconnected' });
+      expect(client.close).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('requireClient', () => {
+    it('throws before connect', () => {
+      mgr = createConnectionManager(makeDeps().deps);
+      expect(() => mgr.requireClient()).toThrow('Not connected');
+    });
+
+    it('returns the client after successful connect', async () => {
+      const client = makeFakeClient({
+        listDatabasesImpl: async () => ({ databases: [{ name: 'db1' }, { name: 'db2' }] }),
+      });
+      mgr = createConnectionManager(makeDeps({ client }).deps);
+      await mgr.connect('mongodb://localhost/');
+      expect(mgr.requireClient()).toBe(client);
+    });
+
+    it('throws after disconnect', async () => {
+      const client = makeFakeClient({
+        listDatabasesImpl: async () => ({ databases: [{ name: 'db1' }, { name: 'db2' }] }),
+      });
+      mgr = createConnectionManager(makeDeps({ client }).deps);
+      await mgr.connect('mongodb://localhost/');
+      await mgr.disconnect();
+      expect(() => mgr.requireClient()).toThrow('Not connected');
+    });
+  });
+
+  describe('concurrent connect', () => {
+    it('returns Already connecting while a connect is in flight', async () => {
+      let release: () => void = () => {};
+      const gate = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      const client = makeFakeClient({
+        connectImpl: async () => {
+          await gate;
+        },
+        listDatabasesImpl: async () => ({ databases: [{ name: 'db1' }, { name: 'db2' }] }),
+      });
+      mgr = createConnectionManager(makeDeps({ client }).deps);
+
+      const first = mgr.connect('mongodb://a/');
+      // Give the scheduler a tick so first reaches connecting state.
+      await Promise.resolve();
+
+      const second = await mgr.connect('mongodb://b/');
+      expect(second).toEqual({ ok: false, error: 'Already connecting' });
+
+      release();
+      const firstResult = await first;
+      expect(firstResult.ok).toBe(true);
+    });
+  });
+
+  describe('ConnectOptions', () => {
+    function makeSingleDbSetup(): {
+      client: FakeClient;
+      built: ReturnType<typeof makeDeps>;
+    } {
+      const client = makeFakeClient({
+        listDatabasesImpl: async () => ({ databases: [{ name: 'only' }] }),
+        listCollectionsImpl: () => [{ name: 'c', type: 'collection' }],
+      });
+      const built = makeDeps({ client });
+      return { client, built };
+    }
+
+    it('autoSelectSingleDb: false skips listCollections and leaves autoSelectedDb null', async () => {
+      const { client, built } = makeSingleDbSetup();
+      mgr = createConnectionManager(built.deps);
+
+      const result = await mgr.connect('mongodb://localhost/', { autoSelectSingleDb: false });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.autoSelectedDb).toBeNull();
+      expect(result.data.collections).toEqual([]);
+      // db('only') would be the listCollections call; db() with no args is for admin.listDatabases.
+      expect(client.db).not.toHaveBeenCalledWith('only');
+    });
+
+    it('persistAsLastUsed: false skips connectionStore.setLastUsed', async () => {
+      const { built } = makeSingleDbSetup();
+      mgr = createConnectionManager(built.deps);
+
+      await mgr.connect('mongodb://localhost/', { persistAsLastUsed: false });
+      expect(built.setLastUsed).not.toHaveBeenCalled();
+    });
+
+    it('loadHistory: false skips historyStore.getAll and returns empty queryHistory', async () => {
+      const { built } = makeSingleDbSetup();
+      mgr = createConnectionManager(built.deps);
+
+      const result = await mgr.connect('mongodb://localhost/', { loadHistory: false });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data.queryHistory).toEqual([]);
+      expect(built.getAll).not.toHaveBeenCalled();
+    });
+
+    it('defaults: all three port calls happen when no options supplied', async () => {
+      const { built } = makeSingleDbSetup();
+      mgr = createConnectionManager(built.deps);
+
+      await mgr.connect('mongodb://localhost/');
+      expect(built.setLastUsed).toHaveBeenCalledWith('mongodb://localhost/');
+      expect(built.getAll).toHaveBeenCalledWith('key:mongodb://localhost/');
+    });
+  });
+
+  describe('onStateChange unsubscribe', () => {
+    it('stops receiving events after unsubscribe', async () => {
+      const client = makeFakeClient({
+        listDatabasesImpl: async () => ({ databases: [{ name: 'db1' }, { name: 'db2' }] }),
+      });
+      mgr = createConnectionManager(makeDeps({ client }).deps);
+      const states: ConnectionState[] = [];
+      const unsub = mgr.onStateChange((s) => states.push(s));
+      unsub();
+      await mgr.connect('mongodb://localhost/');
+      expect(states).toEqual([]);
+    });
+  });
+});

--- a/src/main/connection-manager.ts
+++ b/src/main/connection-manager.ts
@@ -1,26 +1,15 @@
 import type { MongoClient } from 'mongodb';
-import type { Result, DbInfo, CollectionInfo, QueryHistoryEntry } from '../shared/types';
+import type {
+  Result,
+  DbInfo,
+  CollectionInfo,
+  QueryHistoryEntry,
+  ConnectionState,
+  ConnectedSession,
+  ConnectOptions,
+} from '../shared/types';
 
-export type ConnectionState =
-  | { status: 'disconnected' }
-  | { status: 'connecting'; uri: string }
-  | { status: 'connected'; uri: string; connectionKey: string }
-  | { status: 'error'; uri: string; error: string };
-
-export interface ConnectedSession {
-  uri: string;
-  connectionKey: string;
-  databases: DbInfo[];
-  queryHistory: QueryHistoryEntry[];
-  autoSelectedDb: string | null;
-  collections: CollectionInfo[];
-}
-
-export interface ConnectOptions {
-  autoSelectSingleDb?: boolean;
-  persistAsLastUsed?: boolean;
-  loadHistory?: boolean;
-}
+export type { ConnectionState, ConnectedSession, ConnectOptions };
 
 export interface ConnectionStorePort {
   setLastUsed(uri: string): void;

--- a/src/main/connection-manager.ts
+++ b/src/main/connection-manager.ts
@@ -1,0 +1,178 @@
+import type { MongoClient } from 'mongodb';
+import type { Result, DbInfo, CollectionInfo, QueryHistoryEntry } from '../shared/types';
+
+export type ConnectionState =
+  | { status: 'disconnected' }
+  | { status: 'connecting'; uri: string }
+  | { status: 'connected'; uri: string; connectionKey: string }
+  | { status: 'error'; uri: string; error: string };
+
+export interface ConnectedSession {
+  uri: string;
+  connectionKey: string;
+  databases: DbInfo[];
+  queryHistory: QueryHistoryEntry[];
+  autoSelectedDb: string | null;
+  collections: CollectionInfo[];
+}
+
+export interface ConnectOptions {
+  autoSelectSingleDb?: boolean;
+  persistAsLastUsed?: boolean;
+  loadHistory?: boolean;
+}
+
+export interface ConnectionStorePort {
+  setLastUsed(uri: string): void;
+}
+
+export interface HistoryStorePort {
+  getAll(key: string): QueryHistoryEntry[];
+}
+
+export interface MongoClientFactoryPort {
+  create(uri: string): MongoClient;
+}
+
+export interface ConnectionManager {
+  connect(uri: string, opts?: ConnectOptions): Promise<Result<ConnectedSession>>;
+  disconnect(): Promise<Result<undefined>>;
+  getState(): ConnectionState;
+  getConnectionKey(): string | null;
+  requireClient(): MongoClient;
+  onStateChange(cb: (s: ConnectionState) => void): () => void;
+}
+
+export interface ConnectionManagerDeps {
+  clientFactory: MongoClientFactoryPort;
+  connectionStore: ConnectionStorePort;
+  historyStore: HistoryStorePort;
+  connectionKeyFromUri: (uri: string) => string;
+}
+
+async function loadDatabases(client: MongoClient): Promise<DbInfo[]> {
+  const result = await client.db().admin().listDatabases();
+  return result.databases.map((db) => ({
+    name: db.name,
+    sizeOnDisk: db.sizeOnDisk ?? 0,
+    empty: db.empty ?? false,
+  }));
+}
+
+async function loadCollections(client: MongoClient, dbName: string): Promise<CollectionInfo[]> {
+  const db = client.db(dbName);
+  const collections = await db.listCollections().toArray();
+  return Promise.all(
+    collections.map(async (c) => {
+      let count: number | undefined;
+      try {
+        count = await db.collection(c.name).estimatedDocumentCount();
+      } catch {
+        // ignore count errors
+      }
+      return { name: c.name, type: c.type ?? 'collection', count };
+    })
+  );
+}
+
+export function createConnectionManager(deps: ConnectionManagerDeps): ConnectionManager {
+  let state: ConnectionState = { status: 'disconnected' };
+  let client: MongoClient | null = null;
+  const subscribers = new Set<(s: ConnectionState) => void>();
+
+  const setState = (next: ConnectionState): void => {
+    state = next;
+    for (const cb of subscribers) cb(state);
+  };
+
+  const connect = async (uri: string, opts: ConnectOptions = {}): Promise<Result<ConnectedSession>> => {
+    if (state.status === 'connecting') {
+      return { ok: false, error: 'Already connecting' };
+    }
+
+    const autoSelectSingleDb = opts.autoSelectSingleDb ?? true;
+    const persistAsLastUsed = opts.persistAsLastUsed ?? true;
+    const loadHistory = opts.loadHistory ?? true;
+
+    setState({ status: 'connecting', uri });
+
+    let created: MongoClient;
+    try {
+      created = deps.clientFactory.create(uri);
+    } catch (err) {
+      setState({ status: 'disconnected' });
+      return { ok: false, error: (err as Error).message };
+    }
+
+    try {
+      await created.connect();
+    } catch (err) {
+      setState({ status: 'disconnected' });
+      return { ok: false, error: (err as Error).message };
+    }
+
+    try {
+      const databases = await loadDatabases(created);
+
+      let autoSelectedDb: string | null = null;
+      let collections: CollectionInfo[] = [];
+      if (autoSelectSingleDb && databases.length === 1) {
+        autoSelectedDb = databases[0].name;
+        collections = await loadCollections(created, autoSelectedDb);
+      }
+
+      const connectionKey = deps.connectionKeyFromUri(uri);
+      const queryHistory = loadHistory ? deps.historyStore.getAll(connectionKey) : [];
+
+      if (persistAsLastUsed) {
+        deps.connectionStore.setLastUsed(uri);
+      }
+
+      client = created;
+      setState({ status: 'connected', uri, connectionKey });
+
+      return {
+        ok: true,
+        data: { uri, connectionKey, databases, queryHistory, autoSelectedDb, collections },
+      };
+    } catch (err) {
+      try {
+        await created.close();
+      } catch {
+        // ignore close errors during rollback
+      }
+      setState({ status: 'disconnected' });
+      return { ok: false, error: (err as Error).message };
+    }
+  };
+
+  const disconnect = async (): Promise<Result<undefined>> => {
+    const c = client;
+    client = null;
+    setState({ status: 'disconnected' });
+    if (!c) return { ok: true, data: undefined };
+    try {
+      await c.close();
+      return { ok: true, data: undefined };
+    } catch (err) {
+      return { ok: false, error: (err as Error).message };
+    }
+  };
+
+  return {
+    connect,
+    disconnect,
+    getState: () => state,
+    getConnectionKey: () => (state.status === 'connected' ? state.connectionKey : null),
+    requireClient: () => {
+      if (!client) throw new Error('Not connected');
+      return client;
+    },
+    onStateChange: (cb) => {
+      subscribers.add(cb);
+      return () => {
+        subscribers.delete(cb);
+      };
+    },
+  };
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -4,15 +4,23 @@ import { fileURLToPath } from 'url';
 import { electronApp, optimizer, is } from '@electron-toolkit/utils';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+import { MongoClient } from 'mongodb';
 import { MongoService } from './mongo-service';
 import { ConnectionStore } from './connection-store';
-import { QueryHistoryStore } from './query-history-store';
+import { QueryHistoryStore, connectionKeyFromUri } from './query-history-store';
+import { createConnectionManager } from './connection-manager';
 import { registerIpcHandlers } from './ipc-handlers';
 
-const mongoService = new MongoService();
 const connectionStore = new ConnectionStore();
 const queryHistoryStore = new QueryHistoryStore();
-registerIpcHandlers(mongoService, connectionStore, queryHistoryStore);
+const connectionManager = createConnectionManager({
+  clientFactory: { create: (uri: string) => new MongoClient(uri) },
+  connectionStore,
+  historyStore: queryHistoryStore,
+  connectionKeyFromUri,
+});
+const mongoService = new MongoService({ conn: connectionManager });
+registerIpcHandlers(mongoService, connectionStore, queryHistoryStore, connectionManager);
 
 function createWindow(): void {
   const mainWindow = new BrowserWindow({

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -20,7 +20,12 @@ const connectionManager = createConnectionManager({
   connectionKeyFromUri,
 });
 const mongoService = new MongoService({ conn: connectionManager });
-registerIpcHandlers(mongoService, connectionStore, queryHistoryStore, connectionManager);
+const broadcast = (channel: string, payload: unknown): void => {
+  for (const w of BrowserWindow.getAllWindows()) {
+    w.webContents.send(channel, payload);
+  }
+};
+registerIpcHandlers(mongoService, connectionStore, queryHistoryStore, connectionManager, broadcast);
 
 function createWindow(): void {
   const mainWindow = new BrowserWindow({

--- a/src/main/ipc-handlers.test.ts
+++ b/src/main/ipc-handlers.test.ts
@@ -4,6 +4,7 @@ import { registerIpcHandlers } from './ipc-handlers';
 import { MongoService } from './mongo-service';
 import { ConnectionStore } from './connection-store';
 import { QueryHistoryStore } from './query-history-store';
+import type { ConnectionManager } from './connection-manager';
 
 const mockShowSaveDialog = vi.fn();
 const mockShowOpenDialog = vi.fn();
@@ -56,8 +57,6 @@ vi.mock('./query-history-store', async (importOriginal) => {
 
 describe('IPC Handlers', () => {
   let mockService: {
-    connect: ReturnType<typeof vi.fn>;
-    disconnect: ReturnType<typeof vi.fn>;
     listDatabases: ReturnType<typeof vi.fn>;
     listCollections: ReturnType<typeof vi.fn>;
     find: ReturnType<typeof vi.fn>;
@@ -81,12 +80,27 @@ describe('IPC Handlers', () => {
     save: ReturnType<typeof vi.fn>;
     clear: ReturnType<typeof vi.fn>;
   };
+  let mockManager: {
+    connect: ReturnType<typeof vi.fn>;
+    disconnect: ReturnType<typeof vi.fn>;
+    getState: ReturnType<typeof vi.fn>;
+    getConnectionKey: ReturnType<typeof vi.fn>;
+    requireClient: ReturnType<typeof vi.fn>;
+    onStateChange: ReturnType<typeof vi.fn>;
+  };
   let handlers: Record<string, (...args: unknown[]) => unknown>;
 
   beforeEach(() => {
-    mockService = {
+    mockManager = {
       connect: vi.fn(),
       disconnect: vi.fn(),
+      getState: vi.fn(),
+      getConnectionKey: vi.fn(),
+      requireClient: vi.fn(),
+      onStateChange: vi.fn(),
+    };
+
+    mockService = {
       listDatabases: vi.fn(),
       listCollections: vi.fn(),
       find: vi.fn(),
@@ -121,7 +135,8 @@ describe('IPC Handlers', () => {
     registerIpcHandlers(
       mockService as unknown as MongoService,
       mockConnStore as unknown as ConnectionStore,
-      mockHistoryStore as unknown as QueryHistoryStore
+      mockHistoryStore as unknown as QueryHistoryStore,
+      mockManager as unknown as ConnectionManager
     );
   });
 
@@ -156,25 +171,25 @@ describe('IPC Handlers', () => {
   });
 
   describe('mongo:connect', () => {
-    it('calls MongoService.connect with URI and returns result', async () => {
-      mockService.connect.mockResolvedValue({ ok: true, data: undefined });
+    it('calls ConnectionManager.connect with URI and returns result', async () => {
+      mockManager.connect.mockResolvedValue({ ok: true, data: { uri: 'mongodb://localhost:27017' } });
       const result = await handlers['mongo:connect']({} as Electron.IpcMainInvokeEvent, 'mongodb://localhost:27017');
-      expect(mockService.connect).toHaveBeenCalledWith('mongodb://localhost:27017');
+      expect(mockManager.connect).toHaveBeenCalledWith('mongodb://localhost:27017');
       expect(result).toEqual({ ok: true, data: undefined });
     });
 
     it('returns error result on failure', async () => {
-      mockService.connect.mockResolvedValue({ ok: false, error: 'Connection refused' });
+      mockManager.connect.mockResolvedValue({ ok: false, error: 'Connection refused' });
       const result = await handlers['mongo:connect']({} as Electron.IpcMainInvokeEvent, 'bad-uri');
       expect(result).toEqual({ ok: false, error: 'Connection refused' });
     });
   });
 
   describe('mongo:disconnect', () => {
-    it('calls MongoService.disconnect', async () => {
-      mockService.disconnect.mockResolvedValue({ ok: true, data: undefined });
+    it('calls ConnectionManager.disconnect', async () => {
+      mockManager.disconnect.mockResolvedValue({ ok: true, data: undefined });
       const result = await handlers['mongo:disconnect']({} as Electron.IpcMainInvokeEvent);
-      expect(mockService.disconnect).toHaveBeenCalled();
+      expect(mockManager.disconnect).toHaveBeenCalled();
       expect(result).toEqual({ ok: true, data: undefined });
     });
   });
@@ -321,7 +336,7 @@ describe('IPC Handlers', () => {
     const key = 'myhost:9999';
 
     beforeEach(async () => {
-      mockService.connect.mockResolvedValue({ ok: true, data: undefined });
+      mockManager.connect.mockResolvedValue({ ok: true, data: { uri } });
       await handlers['mongo:connect']({} as Electron.IpcMainInvokeEvent, uri);
     });
 

--- a/src/main/ipc-handlers.test.ts
+++ b/src/main/ipc-handlers.test.ts
@@ -4,7 +4,8 @@ import { registerIpcHandlers } from './ipc-handlers';
 import { MongoService } from './mongo-service';
 import { ConnectionStore } from './connection-store';
 import { QueryHistoryStore } from './query-history-store';
-import type { ConnectionManager } from './connection-manager';
+import type { ConnectionManager, ConnectedSession, ConnectionState } from './connection-manager';
+import type { Broadcast } from './ipc-handlers';
 
 const mockShowSaveDialog = vi.fn();
 const mockShowOpenDialog = vi.fn();
@@ -88,17 +89,26 @@ describe('IPC Handlers', () => {
     requireClient: ReturnType<typeof vi.fn>;
     onStateChange: ReturnType<typeof vi.fn>;
   };
+  let mockBroadcast: ReturnType<typeof vi.fn<Broadcast>>;
+  let stateChangeCb: ((s: ConnectionState) => void) | null;
   let handlers: Record<string, (...args: unknown[]) => unknown>;
 
   beforeEach(() => {
+    stateChangeCb = null;
     mockManager = {
       connect: vi.fn(),
       disconnect: vi.fn(),
       getState: vi.fn(),
       getConnectionKey: vi.fn(),
       requireClient: vi.fn(),
-      onStateChange: vi.fn(),
+      onStateChange: vi.fn((cb: (s: ConnectionState) => void) => {
+        stateChangeCb = cb;
+        return () => {
+          stateChangeCb = null;
+        };
+      }),
     };
+    mockBroadcast = vi.fn<Broadcast>();
 
     mockService = {
       listDatabases: vi.fn(),
@@ -136,7 +146,8 @@ describe('IPC Handlers', () => {
       mockService as unknown as MongoService,
       mockConnStore as unknown as ConnectionStore,
       mockHistoryStore as unknown as QueryHistoryStore,
-      mockManager as unknown as ConnectionManager
+      mockManager as unknown as ConnectionManager,
+      mockBroadcast
     );
   });
 
@@ -171,16 +182,37 @@ describe('IPC Handlers', () => {
   });
 
   describe('mongo:connect', () => {
-    it('calls ConnectionManager.connect with URI and returns result', async () => {
-      mockManager.connect.mockResolvedValue({ ok: true, data: { uri: 'mongodb://localhost:27017' } });
-      const result = await handlers['mongo:connect']({} as Electron.IpcMainInvokeEvent, 'mongodb://localhost:27017');
-      expect(mockManager.connect).toHaveBeenCalledWith('mongodb://localhost:27017');
-      expect(result).toEqual({ ok: true, data: undefined });
+    const session: ConnectedSession = {
+      uri: 'mongodb://localhost:27017',
+      connectionKey: 'localhost:27017',
+      databases: [{ name: 'db1', sizeOnDisk: 1, empty: false }],
+      queryHistory: [],
+      autoSelectedDb: 'db1',
+      collections: [],
+    };
+
+    it('delegates to ConnectionManager.connect and returns full ConnectedSession', async () => {
+      mockManager.connect.mockResolvedValue({ ok: true, data: session });
+      const result = await handlers['mongo:connect'](
+        {} as Electron.IpcMainInvokeEvent,
+        'mongodb://localhost:27017',
+        undefined
+      );
+      expect(mockManager.connect).toHaveBeenCalledWith('mongodb://localhost:27017', undefined);
+      expect(result).toEqual({ ok: true, data: session });
+    });
+
+    it('forwards ConnectOptions to manager.connect', async () => {
+      mockManager.connect.mockResolvedValue({ ok: true, data: session });
+      await handlers['mongo:connect']({} as Electron.IpcMainInvokeEvent, 'mongodb://localhost:27017', {
+        loadHistory: false,
+      });
+      expect(mockManager.connect).toHaveBeenCalledWith('mongodb://localhost:27017', { loadHistory: false });
     });
 
     it('returns error result on failure', async () => {
       mockManager.connect.mockResolvedValue({ ok: false, error: 'Connection refused' });
-      const result = await handlers['mongo:connect']({} as Electron.IpcMainInvokeEvent, 'bad-uri');
+      const result = await handlers['mongo:connect']({} as Electron.IpcMainInvokeEvent, 'bad-uri', undefined);
       expect(result).toEqual({ ok: false, error: 'Connection refused' });
     });
   });
@@ -332,31 +364,64 @@ describe('IPC Handlers', () => {
   });
 
   describe('history (per-connection)', () => {
-    const uri = 'mongodb://myhost:9999/testdb';
     const key = 'myhost:9999';
 
-    beforeEach(async () => {
-      mockManager.connect.mockResolvedValue({ ok: true, data: { uri } });
-      await handlers['mongo:connect']({} as Electron.IpcMainInvokeEvent, uri);
+    beforeEach(() => {
+      mockManager.getConnectionKey.mockReturnValue(key);
     });
 
-    it('load returns entries for current connection key', () => {
+    it('load reads connection key from manager and returns entries', () => {
       const entries = [{ id: '1', type: 'filter', query: '{}', db: 'test', collection: 'users', timestamp: 1000 }];
       mockHistoryStore.getAll.mockReturnValue(entries);
       const result = handlers['history:load']({} as Electron.IpcMainInvokeEvent);
+      expect(mockManager.getConnectionKey).toHaveBeenCalled();
       expect(mockHistoryStore.getAll).toHaveBeenCalledWith(key);
       expect(result).toEqual(entries);
     });
 
-    it('save passes connection key to QueryHistoryStore', () => {
+    it('save passes connection key (from manager) to QueryHistoryStore', () => {
       const entries = [{ id: '1', type: 'filter', query: '{}', db: 'test', collection: 'users', timestamp: 1000 }];
       handlers['history:save']({} as Electron.IpcMainInvokeEvent, entries);
       expect(mockHistoryStore.save).toHaveBeenCalledWith(key, entries);
     });
 
-    it('clear passes connection key to QueryHistoryStore', () => {
+    it('clear passes connection key (from manager) to QueryHistoryStore', () => {
       handlers['history:clear']({} as Electron.IpcMainInvokeEvent);
       expect(mockHistoryStore.clear).toHaveBeenCalledWith(key);
+    });
+
+    it('load throws when manager reports no active connection', () => {
+      mockManager.getConnectionKey.mockReturnValue(null);
+      expect(() => handlers['history:load']({} as Electron.IpcMainInvokeEvent)).toThrow('Not connected');
+      expect(mockHistoryStore.getAll).not.toHaveBeenCalled();
+    });
+
+    it('save throws when manager reports no active connection', () => {
+      mockManager.getConnectionKey.mockReturnValue(null);
+      expect(() => handlers['history:save']({} as Electron.IpcMainInvokeEvent, [])).toThrow('Not connected');
+      expect(mockHistoryStore.save).not.toHaveBeenCalled();
+    });
+
+    it('clear throws when manager reports no active connection', () => {
+      mockManager.getConnectionKey.mockReturnValue(null);
+      expect(() => handlers['history:clear']({} as Electron.IpcMainInvokeEvent)).toThrow('Not connected');
+      expect(mockHistoryStore.clear).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('connection:state broadcast', () => {
+    it('subscribes to manager.onStateChange on registration', () => {
+      expect(mockManager.onStateChange).toHaveBeenCalledTimes(1);
+      expect(stateChangeCb).toBeTypeOf('function');
+    });
+
+    it('broadcasts on every state transition', () => {
+      const connecting: ConnectionState = { status: 'connecting', uri: 'mongodb://x' };
+      const connected: ConnectionState = { status: 'connected', uri: 'mongodb://x', connectionKey: 'x' };
+      stateChangeCb!(connecting);
+      stateChangeCb!(connected);
+      expect(mockBroadcast).toHaveBeenNthCalledWith(1, 'connection:state', connecting);
+      expect(mockBroadcast).toHaveBeenNthCalledWith(2, 'connection:state', connected);
     });
   });
 

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -5,13 +5,15 @@ import path from 'path';
 import { createGunzip, createGzip } from 'zlib';
 import type { MongoService } from './mongo-service';
 import type { ConnectionStore } from './connection-store';
+import type { ConnectionManager } from './connection-manager';
 import { connectionKeyFromUri, type QueryHistoryStore } from './query-history-store';
 import type { Result, FindOpts, SavedConnection, QueryHistoryEntry, PickedFile, ImportOptions } from '../shared/types';
 
 export function registerIpcHandlers(
   service: MongoService,
   connStore: ConnectionStore,
-  historyStore: QueryHistoryStore
+  historyStore: QueryHistoryStore,
+  manager: ConnectionManager
 ): void {
   const wrap = <T>(fn: (...args: unknown[]) => Promise<Result<T>>) => {
     return async (_event: Electron.IpcMainInvokeEvent, ...args: unknown[]): Promise<Result<T>> => {
@@ -33,16 +35,19 @@ export function registerIpcHandlers(
 
   ipcMain.handle(
     'mongo:connect',
-    wrap(async (uri: unknown) => {
-      const result = await service.connect(uri as string);
-      if (result.ok) currentUri = uri as string;
-      return result;
+    wrap(async (uri: unknown): Promise<Result<undefined>> => {
+      const result = await manager.connect(uri as string);
+      if (result.ok) {
+        currentUri = uri as string;
+        return { ok: true, data: undefined };
+      }
+      return { ok: false, error: result.error };
     })
   );
   ipcMain.handle(
     'mongo:disconnect',
     wrap(async () => {
-      const result = await service.disconnect();
+      const result = await manager.disconnect();
       currentUri = '';
       return result;
     })

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -5,15 +5,18 @@ import path from 'path';
 import { createGunzip, createGzip } from 'zlib';
 import type { MongoService } from './mongo-service';
 import type { ConnectionStore } from './connection-store';
-import type { ConnectionManager } from './connection-manager';
-import { connectionKeyFromUri, type QueryHistoryStore } from './query-history-store';
+import type { ConnectionManager, ConnectOptions } from './connection-manager';
+import type { QueryHistoryStore } from './query-history-store';
 import type { Result, FindOpts, SavedConnection, QueryHistoryEntry, PickedFile, ImportOptions } from '../shared/types';
+
+export type Broadcast = (channel: string, payload: unknown) => void;
 
 export function registerIpcHandlers(
   service: MongoService,
   connStore: ConnectionStore,
   historyStore: QueryHistoryStore,
-  manager: ConnectionManager
+  manager: ConnectionManager,
+  broadcast: Broadcast = () => {}
 ): void {
   const wrap = <T>(fn: (...args: unknown[]) => Promise<Result<T>>) => {
     return async (_event: Electron.IpcMainInvokeEvent, ...args: unknown[]): Promise<Result<T>> => {
@@ -31,27 +34,24 @@ export function registerIpcHandlers(
     };
   };
 
-  let currentUri = '';
+  manager.onStateChange((state) => {
+    broadcast('connection:state', state);
+  });
 
   ipcMain.handle(
     'mongo:connect',
-    wrap(async (uri: unknown): Promise<Result<undefined>> => {
-      const result = await manager.connect(uri as string);
-      if (result.ok) {
-        currentUri = uri as string;
-        return { ok: true, data: undefined };
-      }
-      return { ok: false, error: result.error };
-    })
+    wrap((uri: unknown, opts: unknown) => manager.connect(uri as string, opts as ConnectOptions | undefined))
   );
   ipcMain.handle(
     'mongo:disconnect',
-    wrap(async () => {
-      const result = await manager.disconnect();
-      currentUri = '';
-      return result;
-    })
+    wrap(() => manager.disconnect())
   );
+
+  const requireConnectionKey = (): string => {
+    const key = manager.getConnectionKey();
+    if (!key) throw new Error('Not connected');
+    return key;
+  };
   ipcMain.handle(
     'mongo:list-databases',
     wrap(() => service.listDatabases())
@@ -132,15 +132,15 @@ export function registerIpcHandlers(
 
   ipcMain.handle(
     'history:load',
-    wrapSync(() => historyStore.getAll(connectionKeyFromUri(currentUri)))
+    wrapSync(() => historyStore.getAll(requireConnectionKey()))
   );
   ipcMain.handle(
     'history:save',
-    wrapSync((entries: unknown) => historyStore.save(connectionKeyFromUri(currentUri), entries as QueryHistoryEntry[]))
+    wrapSync((entries: unknown) => historyStore.save(requireConnectionKey(), entries as QueryHistoryEntry[]))
   );
   ipcMain.handle(
     'history:clear',
-    wrapSync(() => historyStore.clear(connectionKeyFromUri(currentUri)))
+    wrapSync(() => historyStore.clear(requireConnectionKey()))
   );
 
   const activeExports = new Map<string, AbortController>();

--- a/src/main/mongo-service.test.ts
+++ b/src/main/mongo-service.test.ts
@@ -1,20 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { MongoClient, ObjectId } from 'mongodb';
+import type { MongoClient } from 'mongodb';
+import { ObjectId } from 'mongodb';
 import { MongoService } from './mongo-service';
-
-// Mock mongodb driver
-vi.mock('mongodb', async () => {
-  const actual = await vi.importActual<typeof import('mongodb')>('mongodb');
-  return {
-    ...actual,
-    MongoClient: vi.fn(function () {}),
-  };
-});
 
 describe('MongoService', () => {
   let service: MongoService;
   let mockClient: {
-    connect: ReturnType<typeof vi.fn>;
     close: ReturnType<typeof vi.fn>;
     db: ReturnType<typeof vi.fn>;
   };
@@ -22,6 +13,7 @@ describe('MongoService', () => {
     listCollections: ReturnType<typeof vi.fn>;
     collection: ReturnType<typeof vi.fn>;
     admin: ReturnType<typeof vi.fn>;
+    dropCollection: ReturnType<typeof vi.fn>;
   };
   let mockCollection: {
     find: ReturnType<typeof vi.fn>;
@@ -33,6 +25,7 @@ describe('MongoService', () => {
     deleteOne: ReturnType<typeof vi.fn>;
     distinct: ReturnType<typeof vi.fn>;
   };
+  let requireClient: ReturnType<typeof vi.fn<() => MongoClient>>;
 
   beforeEach(() => {
     mockCollection = {
@@ -49,9 +42,9 @@ describe('MongoService', () => {
       listCollections: vi.fn().mockReturnValue({ toArray: vi.fn().mockResolvedValue([]) }),
       collection: vi.fn().mockReturnValue(mockCollection),
       admin: vi.fn(),
+      dropCollection: vi.fn().mockResolvedValue(undefined),
     };
     mockClient = {
-      connect: vi.fn().mockResolvedValue(undefined),
       close: vi.fn().mockResolvedValue(undefined),
       db: vi.fn().mockReturnValue(mockDb),
     };
@@ -63,43 +56,16 @@ describe('MongoService', () => {
         ],
       }),
     });
-    vi.mocked(MongoClient).mockImplementation(function () {
-      return mockClient as unknown as MongoClient;
-    });
-    service = new MongoService();
+    requireClient = vi.fn().mockReturnValue(mockClient as unknown as MongoClient);
+    service = new MongoService({ conn: { requireClient: () => requireClient() } });
   });
 
   afterEach(() => {
     vi.clearAllMocks();
   });
 
-  describe('connect', () => {
-    it('calls MongoClient.connect with URI', async () => {
-      const result = await service.connect('mongodb://localhost:27017');
-      expect(MongoClient).toHaveBeenCalledWith('mongodb://localhost:27017');
-      expect(mockClient.connect).toHaveBeenCalled();
-      expect(result).toEqual({ ok: true, data: undefined });
-    });
-
-    it('with bad URI returns error result', async () => {
-      mockClient.connect.mockRejectedValue(new Error('Invalid connection string'));
-      const result = await service.connect('bad-uri');
-      expect(result).toEqual({ ok: false, error: 'Invalid connection string' });
-    });
-  });
-
-  describe('disconnect', () => {
-    it('closes client', async () => {
-      await service.connect('mongodb://localhost:27017');
-      const result = await service.disconnect();
-      expect(mockClient.close).toHaveBeenCalled();
-      expect(result).toEqual({ ok: true, data: undefined });
-    });
-  });
-
   describe('listDatabases', () => {
     it('returns DbInfo[]', async () => {
-      await service.connect('mongodb://localhost:27017');
       const result = await service.listDatabases();
       expect(result).toEqual({
         ok: true,
@@ -110,7 +76,10 @@ describe('MongoService', () => {
       });
     });
 
-    it('when not connected throws', async () => {
+    it('when not connected returns error', async () => {
+      requireClient.mockImplementation(() => {
+        throw new Error('Not connected');
+      });
       const result = await service.listDatabases();
       expect(result).toEqual({ ok: false, error: 'Not connected' });
     });
@@ -124,7 +93,6 @@ describe('MongoService', () => {
           { name: 'orders', type: 'collection' },
         ]),
       });
-      await service.connect('mongodb://localhost:27017');
       const result = await service.listCollections('testdb');
       expect(mockClient.db).toHaveBeenCalledWith('testdb');
       expect(result).toEqual({
@@ -154,7 +122,6 @@ describe('MongoService', () => {
       mockCollection.find.mockReturnValue(mockCursor);
       mockCollection.countDocuments.mockResolvedValue(2);
 
-      await service.connect('mongodb://localhost:27017');
       const result = await service.find('testdb', 'users', {
         filter: { name: 'Alice' },
         sort: { name: 1 },
@@ -166,7 +133,6 @@ describe('MongoService', () => {
       if (result.ok) {
         expect(result.data.totalCount).toBe(2);
         expect(result.data.docs).toHaveLength(2);
-        // EJSON serialization: ObjectId and Date should be serialized
         const doc = result.data.docs[0];
         expect(doc._id).toBeDefined();
         expect(doc.name).toBe('Alice');
@@ -181,7 +147,6 @@ describe('MongoService', () => {
   describe('count', () => {
     it('returns number', async () => {
       mockCollection.countDocuments.mockResolvedValue(42);
-      await service.connect('mongodb://localhost:27017');
       const result = await service.count('testdb', 'users', { active: true });
       expect(result).toEqual({ ok: true, data: 42 });
       expect(mockCollection.countDocuments).toHaveBeenCalledWith({ active: true });
@@ -197,7 +162,6 @@ describe('MongoService', () => {
       };
       mockCollection.aggregate.mockReturnValue(mockCursor);
 
-      await service.connect('mongodb://localhost:27017');
       const result = await service.aggregate('testdb', 'users', [{ $group: { _id: null, total: { $sum: 1 } } }]);
 
       expect(result.ok).toBe(true);
@@ -209,7 +173,10 @@ describe('MongoService', () => {
       expect(mockCollection.aggregate).toHaveBeenCalledWith([{ $group: { _id: null, total: { $sum: 1 } } }]);
     });
 
-    it('returns error when not connected', async () => {
+    it('when not connected returns error', async () => {
+      requireClient.mockImplementation(() => {
+        throw new Error('Not connected');
+      });
       const result = await service.aggregate('testdb', 'users', []);
       expect(result).toEqual({ ok: false, error: 'Not connected' });
     });
@@ -221,7 +188,6 @@ describe('MongoService', () => {
       mockCollection.insertOne.mockResolvedValue({ insertedId });
       mockCollection.findOne.mockResolvedValue({ _id: insertedId, name: 'Alice' });
 
-      await service.connect('mongodb://localhost:27017');
       const result = await service.insertOne('testdb', 'users', { name: 'Alice' });
 
       expect(result.ok).toBe(true);
@@ -232,7 +198,10 @@ describe('MongoService', () => {
       expect(mockCollection.insertOne).toHaveBeenCalled();
     });
 
-    it('returns error when not connected', async () => {
+    it('when not connected returns error', async () => {
+      requireClient.mockImplementation(() => {
+        throw new Error('Not connected');
+      });
       const result = await service.insertOne('testdb', 'users', { name: 'Alice' });
       expect(result).toEqual({ ok: false, error: 'Not connected' });
     });
@@ -244,7 +213,6 @@ describe('MongoService', () => {
       mockCollection.replaceOne.mockResolvedValue({ modifiedCount: 1 });
       mockCollection.findOne.mockResolvedValue({ _id: oid, name: 'Bob' });
 
-      await service.connect('mongodb://localhost:27017');
       const result = await service.updateOne('testdb', 'users', { $oid: '507f1f77bcf86cd799439011' }, { name: 'Bob' });
 
       expect(result.ok).toBe(true);
@@ -259,7 +227,6 @@ describe('MongoService', () => {
       mockCollection.replaceOne.mockResolvedValue({ modifiedCount: 1 });
       mockCollection.findOne.mockResolvedValue({ _id: 'my-string-id', name: 'Bob' });
 
-      await service.connect('mongodb://localhost:27017');
       const result = await service.updateOne('testdb', 'users', 'my-string-id', { name: 'Bob' });
 
       expect(result.ok).toBe(true);
@@ -269,7 +236,10 @@ describe('MongoService', () => {
       expect(mockCollection.replaceOne).toHaveBeenCalledWith({ _id: 'my-string-id' }, { name: 'Bob' });
     });
 
-    it('returns error when not connected', async () => {
+    it('when not connected returns error', async () => {
+      requireClient.mockImplementation(() => {
+        throw new Error('Not connected');
+      });
       const result = await service.updateOne('testdb', 'users', '507f1f77bcf86cd799439011', { name: 'Bob' });
       expect(result).toEqual({ ok: false, error: 'Not connected' });
     });
@@ -280,7 +250,6 @@ describe('MongoService', () => {
       const oid = new ObjectId('507f1f77bcf86cd799439011');
       mockCollection.deleteOne.mockResolvedValue({ deletedCount: 1 });
 
-      await service.connect('mongodb://localhost:27017');
       const result = await service.deleteOne('testdb', 'users', { $oid: '507f1f77bcf86cd799439011' });
 
       expect(result).toEqual({ ok: true, data: undefined });
@@ -290,14 +259,16 @@ describe('MongoService', () => {
     it('with string id queries with string, not ObjectId', async () => {
       mockCollection.deleteOne.mockResolvedValue({ deletedCount: 1 });
 
-      await service.connect('mongodb://localhost:27017');
       const result = await service.deleteOne('testdb', 'users', 'my-string-id');
 
       expect(result).toEqual({ ok: true, data: undefined });
       expect(mockCollection.deleteOne).toHaveBeenCalledWith({ _id: 'my-string-id' });
     });
 
-    it('returns error when not connected', async () => {
+    it('when not connected returns error', async () => {
+      requireClient.mockImplementation(() => {
+        throw new Error('Not connected');
+      });
       const result = await service.deleteOne('testdb', 'users', '507f1f77bcf86cd799439011');
       expect(result).toEqual({ ok: false, error: 'Not connected' });
     });
@@ -308,7 +279,6 @@ describe('MongoService', () => {
       const objectId = new ObjectId('507f1f77bcf86cd799439011');
       mockCollection.distinct.mockResolvedValue([objectId, 'hello', 42]);
 
-      await service.connect('mongodb://localhost:27017');
       const result = await service.distinct('testdb', 'users', 'status');
 
       expect(result.ok).toBe(true);
@@ -319,7 +289,10 @@ describe('MongoService', () => {
       expect(mockCollection.distinct).toHaveBeenCalledWith('status');
     });
 
-    it('returns error when not connected', async () => {
+    it('when not connected returns error', async () => {
+      requireClient.mockImplementation(() => {
+        throw new Error('Not connected');
+      });
       const result = await service.distinct('testdb', 'users', 'status');
       expect(result).toEqual({ ok: false, error: 'Not connected' });
     });
@@ -328,7 +301,6 @@ describe('MongoService', () => {
       const values = Array.from({ length: 15 }, (_, i) => `val${i}`);
       mockCollection.distinct.mockResolvedValue(values);
 
-      await service.connect('mongodb://localhost:27017');
       const result = await service.distinct('testdb', 'users', 'status', 10);
 
       expect(result.ok).toBe(true);
@@ -341,7 +313,6 @@ describe('MongoService', () => {
     it('sets truncated to false when under limit', async () => {
       mockCollection.distinct.mockResolvedValue(['a', 'b', 'c']);
 
-      await service.connect('mongodb://localhost:27017');
       const result = await service.distinct('testdb', 'users', 'status');
 
       expect(result.ok).toBe(true);
@@ -353,7 +324,6 @@ describe('MongoService', () => {
     it('handles MongoDB errors gracefully', async () => {
       mockCollection.distinct.mockRejectedValue(new Error('Query failed'));
 
-      await service.connect('mongodb://localhost:27017');
       const result = await service.distinct('testdb', 'users', 'status');
 
       expect(result).toEqual({ ok: false, error: 'Query failed' });
@@ -374,15 +344,12 @@ describe('MongoService', () => {
       mockCollection.find.mockReturnValue(mockCursor);
       mockCollection.countDocuments.mockResolvedValue(1);
 
-      await service.connect('mongodb://localhost:27017');
       const result = await service.find('testdb', 'users', {});
 
       expect(result.ok).toBe(true);
       if (result.ok) {
         const doc = result.data.docs[0];
-        // EJSON serialized ObjectId should have $oid
         expect(doc._id).toEqual({ $oid: '507f1f77bcf86cd799439011' });
-        // EJSON serialized Date should have $date
         expect(doc.createdAt).toEqual({ $date: '2024-01-01T00:00:00Z' });
       }
     });

--- a/src/main/mongo-service.ts
+++ b/src/main/mongo-service.ts
@@ -1,6 +1,7 @@
-import { MongoClient, MongoBulkWriteError } from 'mongodb';
+import { MongoBulkWriteError } from 'mongodb';
 import { BSON, EJSON } from 'bson';
 import type { Readable, Writable } from 'stream';
+import type { ConnectionManager } from './connection-manager';
 import type {
   Result,
   DbInfo,
@@ -11,34 +12,21 @@ import type {
   DistinctResult,
 } from '../shared/types';
 
+export interface MongoServiceDeps {
+  conn: Pick<ConnectionManager, 'requireClient'>;
+}
+
 export class MongoService {
-  private client: MongoClient | null = null;
+  private readonly conn: Pick<ConnectionManager, 'requireClient'>;
 
-  async connect(uri: string): Promise<Result<undefined>> {
-    try {
-      this.client = new MongoClient(uri);
-      await this.client.connect();
-      return { ok: true, data: undefined };
-    } catch (err) {
-      this.client = null;
-      return { ok: false, error: (err as Error).message };
-    }
-  }
-
-  async disconnect(): Promise<Result<undefined>> {
-    try {
-      await this.client?.close();
-      this.client = null;
-      return { ok: true, data: undefined };
-    } catch (err) {
-      return { ok: false, error: (err as Error).message };
-    }
+  constructor(deps: MongoServiceDeps) {
+    this.conn = deps.conn;
   }
 
   async listDatabases(): Promise<Result<DbInfo[]>> {
-    if (!this.client) return { ok: false, error: 'Not connected' };
     try {
-      const result = await this.client.db().admin().listDatabases();
+      const client = this.conn.requireClient();
+      const result = await client.db().admin().listDatabases();
       const databases: DbInfo[] = result.databases.map((db) => ({
         name: db.name,
         sizeOnDisk: db.sizeOnDisk ?? 0,
@@ -51,9 +39,9 @@ export class MongoService {
   }
 
   async listCollections(dbName: string): Promise<Result<CollectionInfo[]>> {
-    if (!this.client) return { ok: false, error: 'Not connected' };
     try {
-      const db = this.client.db(dbName);
+      const client = this.conn.requireClient();
+      const db = client.db(dbName);
       const collections = await db.listCollections().toArray();
       const data: CollectionInfo[] = await Promise.all(
         collections.map(async (c) => {
@@ -73,9 +61,9 @@ export class MongoService {
   }
 
   async find(dbName: string, collName: string, opts: FindOpts): Promise<Result<FindResult>> {
-    if (!this.client) return { ok: false, error: 'Not connected' };
     try {
-      const collection = this.client.db(dbName).collection(collName);
+      const client = this.conn.requireClient();
+      const collection = client.db(dbName).collection(collName);
       const filter = opts.filter ?? {};
       const cursor = collection.find(filter);
       if (opts.sort) cursor.sort(opts.sort);
@@ -84,7 +72,6 @@ export class MongoService {
 
       const [rawDocs, totalCount] = await Promise.all([cursor.toArray(), collection.countDocuments(filter)]);
 
-      // EJSON serialize to handle ObjectId, Date, etc.
       const docs = rawDocs.map((doc) => EJSON.serialize(doc) as Record<string, unknown>);
 
       return { ok: true, data: { docs, totalCount } };
@@ -98,9 +85,9 @@ export class MongoService {
     collName: string,
     pipeline: Record<string, unknown>[]
   ): Promise<Result<Record<string, unknown>[]>> {
-    if (!this.client) return { ok: false, error: 'Not connected' };
     try {
-      const collection = this.client.db(dbName).collection(collName);
+      const client = this.conn.requireClient();
+      const collection = client.db(dbName).collection(collName);
       const rawDocs = await collection.aggregate(pipeline).toArray();
       const docs = rawDocs.map((doc) => EJSON.serialize(doc) as Record<string, unknown>);
       return { ok: true, data: docs };
@@ -110,9 +97,9 @@ export class MongoService {
   }
 
   async count(dbName: string, collName: string, filter: Record<string, unknown> = {}): Promise<Result<number>> {
-    if (!this.client) return { ok: false, error: 'Not connected' };
     try {
-      const collection = this.client.db(dbName).collection(collName);
+      const client = this.conn.requireClient();
+      const collection = client.db(dbName).collection(collName);
       const count = await collection.countDocuments(filter);
       return { ok: true, data: count };
     } catch (err) {
@@ -125,9 +112,9 @@ export class MongoService {
     collName: string,
     doc: Record<string, unknown>
   ): Promise<Result<Record<string, unknown>>> {
-    if (!this.client) return { ok: false, error: 'Not connected' };
     try {
-      const collection = this.client.db(dbName).collection(collName);
+      const client = this.conn.requireClient();
+      const collection = client.db(dbName).collection(collName);
       const deserialized = EJSON.deserialize(doc) as Record<string, unknown>;
       const result = await collection.insertOne(deserialized);
       const inserted = await collection.findOne({ _id: result.insertedId });
@@ -143,9 +130,9 @@ export class MongoService {
     id: unknown,
     doc: Record<string, unknown>
   ): Promise<Result<Record<string, unknown>>> {
-    if (!this.client) return { ok: false, error: 'Not connected' };
     try {
-      const collection = this.client.db(dbName).collection(collName);
+      const client = this.conn.requireClient();
+      const collection = client.db(dbName).collection(collName);
       const deserialized = EJSON.deserialize(doc) as Record<string, unknown>;
       const { _id, ...updateFields } = deserialized;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -159,9 +146,9 @@ export class MongoService {
   }
 
   async sampleFields(dbName: string, collName: string): Promise<Result<string[]>> {
-    if (!this.client) return { ok: false, error: 'Not connected' };
     try {
-      const collection = this.client.db(dbName).collection(collName);
+      const client = this.conn.requireClient();
+      const collection = client.db(dbName).collection(collName);
       const docs = await collection.find({}).limit(50).toArray();
       const keySet = new Set<string>();
       for (const doc of docs) {
@@ -183,9 +170,9 @@ export class MongoService {
     onProgress: (count: number) => void,
     signal: AbortSignal
   ): Promise<Result<number>> {
-    if (!this.client) return { ok: false, error: 'Not connected' };
     try {
-      const collection = this.client.db(dbName).collection(collName);
+      const client = this.conn.requireClient();
+      const collection = client.db(dbName).collection(collName);
       const cursor = collection.find({});
       let count = 0;
       let lastProgressTime = 0;
@@ -225,9 +212,9 @@ export class MongoService {
     onProgress: (count: number) => void,
     signal: AbortSignal
   ): Promise<Result<{ inserted: number; skipped: number }>> {
-    if (!this.client) return { ok: false, error: 'Not connected' };
     try {
-      const collection = this.client.db(dbName).collection(collName);
+      const client = this.conn.requireClient();
+      const collection = client.db(dbName).collection(collName);
 
       if (options.clearFirst) {
         await collection.deleteMany({});
@@ -323,7 +310,6 @@ export class MongoService {
         leftover = leftover.subarray(offset);
       }
 
-      // Flush remaining docs
       await flush();
       onProgress(inserted + skipped);
 
@@ -334,9 +320,9 @@ export class MongoService {
   }
 
   async distinct(dbName: string, collName: string, field: string, maxValues = 1000): Promise<Result<DistinctResult>> {
-    if (!this.client) return { ok: false, error: 'Not connected' };
     try {
-      const collection = this.client.db(dbName).collection(collName);
+      const client = this.conn.requireClient();
+      const collection = client.db(dbName).collection(collName);
       const rawValues = await collection.distinct(field);
       const truncated = rawValues.length > maxValues;
       const sliced = truncated ? rawValues.slice(0, maxValues) : rawValues;
@@ -348,9 +334,9 @@ export class MongoService {
   }
 
   async dropCollection(dbName: string, collName: string): Promise<Result<undefined>> {
-    if (!this.client) return { ok: false, error: 'Not connected' };
     try {
-      await this.client.db(dbName).dropCollection(collName);
+      const client = this.conn.requireClient();
+      await client.db(dbName).dropCollection(collName);
       return { ok: true, data: undefined };
     } catch (err) {
       return { ok: false, error: (err as Error).message };
@@ -358,9 +344,9 @@ export class MongoService {
   }
 
   async deleteOne(dbName: string, collName: string, id: unknown): Promise<Result<undefined>> {
-    if (!this.client) return { ok: false, error: 'Not connected' };
     try {
-      const collection = this.client.db(dbName).collection(collName);
+      const client = this.conn.requireClient();
+      const collection = client.db(dbName).collection(collName);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const filterid = (EJSON.deserialize({ _id: id }) as Record<string, unknown>)._id as any;
       await collection.deleteOne({ _id: filterid });

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -14,10 +14,14 @@ import type {
   PickedFile,
   DistinctResult,
 } from '../shared/types';
+import type { ConnectionState, ConnectedSession, ConnectOptions } from '../main/connection-manager';
+
+export type { ConnectionState, ConnectedSession, ConnectOptions };
 
 interface MongoApi {
-  connect(uri: string): Promise<Result<undefined>>;
+  connect(uri: string, opts?: ConnectOptions): Promise<Result<ConnectedSession>>;
   disconnect(): Promise<Result<undefined>>;
+  onConnectionState(cb: (state: ConnectionState) => void): () => void;
   listDatabases(): Promise<Result<DbInfo[]>>;
   listCollections(db: string): Promise<Result<CollectionInfo[]>>;
   find(db: string, collection: string, opts: FindOpts): Promise<Result<FindResult>>;

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('electron', () => ({
+  contextBridge: { exposeInMainWorld: vi.fn() },
+  ipcRenderer: { invoke: vi.fn(), on: vi.fn(), off: vi.fn() },
+}));
+
+vi.mock('@electron-toolkit/preload', () => ({
+  electronAPI: {},
+}));
+
+import { createApi } from './index';
+import type { ConnectionState, ConnectedSession } from '../main/connection-manager';
+
+describe('preload createApi', () => {
+  let invoke: ReturnType<typeof vi.fn>;
+  let on: ReturnType<typeof vi.fn>;
+  let off: ReturnType<typeof vi.fn>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let ipcRenderer: any;
+
+  beforeEach(() => {
+    invoke = vi.fn();
+    on = vi.fn();
+    off = vi.fn();
+    ipcRenderer = { invoke, on, off };
+  });
+
+  describe('connect', () => {
+    it('invokes mongo:connect with uri and forwards the ConnectedSession result', async () => {
+      const session: ConnectedSession = {
+        uri: 'mongodb://localhost:27017',
+        connectionKey: 'key-1',
+        databases: [{ name: 'db1', sizeOnDisk: 100, empty: false }],
+        queryHistory: [],
+        autoSelectedDb: 'db1',
+        collections: [],
+      };
+      invoke.mockResolvedValue({ ok: true, data: session });
+      const api = createApi(ipcRenderer);
+
+      const result = await api.connect('mongodb://localhost:27017');
+
+      expect(invoke).toHaveBeenCalledWith('mongo:connect', 'mongodb://localhost:27017', undefined);
+      expect(result).toEqual({ ok: true, data: session });
+    });
+
+    it('forwards ConnectOptions to the main process', async () => {
+      invoke.mockResolvedValue({ ok: false, error: 'boom' });
+      const api = createApi(ipcRenderer);
+
+      await api.connect('mongodb://localhost:27017', {
+        autoSelectSingleDb: false,
+        persistAsLastUsed: false,
+        loadHistory: false,
+      });
+
+      expect(invoke).toHaveBeenCalledWith('mongo:connect', 'mongodb://localhost:27017', {
+        autoSelectSingleDb: false,
+        persistAsLastUsed: false,
+        loadHistory: false,
+      });
+    });
+  });
+
+  describe('onConnectionState', () => {
+    it('registers a listener on connection:state and forwards the state payload', () => {
+      const api = createApi(ipcRenderer);
+      const cb = vi.fn();
+
+      api.onConnectionState(cb);
+
+      expect(on).toHaveBeenCalledTimes(1);
+      const [channel, handler] = on.mock.calls[0];
+      expect(channel).toBe('connection:state');
+
+      const state: ConnectionState = { status: 'connecting', uri: 'mongodb://localhost' };
+      (handler as (event: unknown, data: ConnectionState) => void)({}, state);
+
+      expect(cb).toHaveBeenCalledWith(state);
+    });
+
+    it('returns an unsubscribe function that removes the exact listener via ipcRenderer.off', () => {
+      const api = createApi(ipcRenderer);
+      const cb = vi.fn();
+
+      const unsubscribe = api.onConnectionState(cb);
+      const registeredHandler = on.mock.calls[0][1];
+
+      unsubscribe();
+
+      expect(off).toHaveBeenCalledWith('connection:state', registeredHandler);
+    });
+
+    it('does not leak listeners: handler registered via on matches the one passed to off', () => {
+      const api = createApi(ipcRenderer);
+
+      const unsub1 = api.onConnectionState(vi.fn());
+      const unsub2 = api.onConnectionState(vi.fn());
+
+      const handler1 = on.mock.calls[0][1];
+      const handler2 = on.mock.calls[1][1];
+      expect(handler1).not.toBe(handler2);
+
+      unsub1();
+      unsub2();
+
+      expect(off).toHaveBeenNthCalledWith(1, 'connection:state', handler1);
+      expect(off).toHaveBeenNthCalledWith(2, 'connection:state', handler2);
+    });
+  });
+});

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -17,6 +17,8 @@ import type {
 } from '../shared/types';
 import type { ConnectionState, ConnectedSession, ConnectOptions } from '../main/connection-manager';
 
+export type { ConnectionState, ConnectedSession, ConnectOptions };
+
 type IpcLike = {
   invoke: (channel: string, ...args: unknown[]) => Promise<unknown>;
   on: (channel: string, listener: (event: unknown, ...args: unknown[]) => void) => void;

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -15,80 +15,108 @@ import type {
   PickedFile,
   DistinctResult,
 } from '../shared/types';
+import type { ConnectionState, ConnectedSession, ConnectOptions } from '../main/connection-manager';
 
-const api = {
-  connect: (uri: string): Promise<Result<undefined>> => ipcRenderer.invoke('mongo:connect', uri),
-  disconnect: (): Promise<Result<undefined>> => ipcRenderer.invoke('mongo:disconnect'),
-  listDatabases: (): Promise<Result<DbInfo[]>> => ipcRenderer.invoke('mongo:list-databases'),
-  listCollections: (db: string): Promise<Result<CollectionInfo[]>> => ipcRenderer.invoke('mongo:list-collections', db),
-  find: (db: string, collection: string, opts: FindOpts): Promise<Result<FindResult>> =>
-    ipcRenderer.invoke('mongo:find', db, collection, opts),
-  count: (db: string, collection: string, filter?: Record<string, unknown>): Promise<Result<number>> =>
-    ipcRenderer.invoke('mongo:count', db, collection, filter ?? {}),
-  aggregate: (
-    db: string,
-    collection: string,
-    pipeline: Record<string, unknown>[]
-  ): Promise<Result<Record<string, unknown>[]>> => ipcRenderer.invoke('mongo:aggregate', db, collection, pipeline),
-  sampleFields: (db: string, collection: string): Promise<Result<string[]>> =>
-    ipcRenderer.invoke('mongo:sample-fields', db, collection),
-  distinct: (db: string, collection: string, field: string): Promise<Result<DistinctResult>> =>
-    ipcRenderer.invoke('mongo:distinct', db, collection, field),
-  insertOne: (db: string, collection: string, doc: Record<string, unknown>): Promise<Result<Record<string, unknown>>> =>
-    ipcRenderer.invoke('mongo:insert-one', db, collection, doc),
-  updateOne: (
-    db: string,
-    collection: string,
-    id: unknown,
-    doc: Record<string, unknown>
-  ): Promise<Result<Record<string, unknown>>> => ipcRenderer.invoke('mongo:update-one', db, collection, id, doc),
-  deleteOne: (db: string, collection: string, id: unknown): Promise<Result<undefined>> =>
-    ipcRenderer.invoke('mongo:delete-one', db, collection, id),
-  dropCollection: (db: string, collection: string): Promise<Result<undefined>> =>
-    ipcRenderer.invoke('mongo:drop-collection', db, collection),
-  listConnections: (): Promise<SavedConnection[]> => ipcRenderer.invoke('connections:list'),
-  saveConnection: (conn: SavedConnection): Promise<void> => ipcRenderer.invoke('connections:save', conn),
-  deleteConnection: (name: string): Promise<void> => ipcRenderer.invoke('connections:delete', name),
-  getLastUsed: (): Promise<string | null> => ipcRenderer.invoke('connections:get-last-used'),
-  setLastUsed: (uri: string): Promise<void> => ipcRenderer.invoke('connections:set-last-used', uri),
-  loadHistory: (): Promise<QueryHistoryEntry[]> => ipcRenderer.invoke('history:load'),
-  saveHistory: (entries: QueryHistoryEntry[]): Promise<void> => ipcRenderer.invoke('history:save', entries),
-  clearHistory: (): Promise<void> => ipcRenderer.invoke('history:clear'),
-  exportCollection: (db: string, collection: string): Promise<Result<number | null>> =>
-    ipcRenderer.invoke('mongo:export-collection', db, collection),
-  cancelExport: (db: string, collection: string): Promise<Result<undefined>> =>
-    ipcRenderer.invoke('mongo:cancel-export', db, collection),
-  onExportProgress: (cb: (data: ExportProgress) => void): (() => void) => {
-    const handler = (_event: Electron.IpcRendererEvent, data: ExportProgress): void => cb(data);
-    ipcRenderer.on('export:progress', handler);
-    return () => ipcRenderer.off('export:progress', handler);
-  },
-  exportDatabase: (db: string): Promise<Result<number | null>> => ipcRenderer.invoke('mongo:export-database', db),
-  cancelExportDatabase: (db: string): Promise<Result<undefined>> =>
-    ipcRenderer.invoke('mongo:cancel-export-database', db),
-  onExportDbProgress: (cb: (data: ExportDbProgress) => void): (() => void) => {
-    const handler = (_event: Electron.IpcRendererEvent, data: ExportDbProgress): void => cb(data);
-    ipcRenderer.on('export-db:progress', handler);
-    return () => ipcRenderer.off('export-db:progress', handler);
-  },
-  pickImportFile: (): Promise<Result<PickedFile[] | null>> => ipcRenderer.invoke('mongo:pick-import-file'),
-  importCollection: (
-    db: string,
-    collection: string,
-    filePath: string,
-    options: ImportOptions
-  ): Promise<Result<{ inserted: number; skipped: number } | null>> =>
-    ipcRenderer.invoke('mongo:import-collection', db, collection, filePath, options),
-  cancelImport: (db: string, collection: string): Promise<Result<undefined>> =>
-    ipcRenderer.invoke('mongo:cancel-import', db, collection),
-  onImportProgress: (cb: (data: ImportProgress) => void): (() => void) => {
-    const handler = (_event: Electron.IpcRendererEvent, data: ImportProgress): void => cb(data);
-    ipcRenderer.on('import:progress', handler);
-    return () => ipcRenderer.off('import:progress', handler);
-  },
+type IpcLike = {
+  invoke: (channel: string, ...args: unknown[]) => Promise<unknown>;
+  on: (channel: string, listener: (event: unknown, ...args: unknown[]) => void) => void;
+  off: (channel: string, listener: (event: unknown, ...args: unknown[]) => void) => void;
 };
 
-export type MongoApi = typeof api;
+export function createApi(ipc: IpcLike) {
+  return {
+    connect: (uri: string, opts?: ConnectOptions): Promise<Result<ConnectedSession>> =>
+      ipc.invoke('mongo:connect', uri, opts) as Promise<Result<ConnectedSession>>,
+    disconnect: (): Promise<Result<undefined>> => ipc.invoke('mongo:disconnect') as Promise<Result<undefined>>,
+    onConnectionState: (cb: (state: ConnectionState) => void): (() => void) => {
+      const handler = (_event: unknown, state: ConnectionState): void => cb(state);
+      ipc.on('connection:state', handler as (event: unknown, ...args: unknown[]) => void);
+      return () => ipc.off('connection:state', handler as (event: unknown, ...args: unknown[]) => void);
+    },
+    listDatabases: (): Promise<Result<DbInfo[]>> => ipc.invoke('mongo:list-databases') as Promise<Result<DbInfo[]>>,
+    listCollections: (db: string): Promise<Result<CollectionInfo[]>> =>
+      ipc.invoke('mongo:list-collections', db) as Promise<Result<CollectionInfo[]>>,
+    find: (db: string, collection: string, opts: FindOpts): Promise<Result<FindResult>> =>
+      ipc.invoke('mongo:find', db, collection, opts) as Promise<Result<FindResult>>,
+    count: (db: string, collection: string, filter?: Record<string, unknown>): Promise<Result<number>> =>
+      ipc.invoke('mongo:count', db, collection, filter ?? {}) as Promise<Result<number>>,
+    aggregate: (
+      db: string,
+      collection: string,
+      pipeline: Record<string, unknown>[]
+    ): Promise<Result<Record<string, unknown>[]>> =>
+      ipc.invoke('mongo:aggregate', db, collection, pipeline) as Promise<Result<Record<string, unknown>[]>>,
+    sampleFields: (db: string, collection: string): Promise<Result<string[]>> =>
+      ipc.invoke('mongo:sample-fields', db, collection) as Promise<Result<string[]>>,
+    distinct: (db: string, collection: string, field: string): Promise<Result<DistinctResult>> =>
+      ipc.invoke('mongo:distinct', db, collection, field) as Promise<Result<DistinctResult>>,
+    insertOne: (
+      db: string,
+      collection: string,
+      doc: Record<string, unknown>
+    ): Promise<Result<Record<string, unknown>>> =>
+      ipc.invoke('mongo:insert-one', db, collection, doc) as Promise<Result<Record<string, unknown>>>,
+    updateOne: (
+      db: string,
+      collection: string,
+      id: unknown,
+      doc: Record<string, unknown>
+    ): Promise<Result<Record<string, unknown>>> =>
+      ipc.invoke('mongo:update-one', db, collection, id, doc) as Promise<Result<Record<string, unknown>>>,
+    deleteOne: (db: string, collection: string, id: unknown): Promise<Result<undefined>> =>
+      ipc.invoke('mongo:delete-one', db, collection, id) as Promise<Result<undefined>>,
+    dropCollection: (db: string, collection: string): Promise<Result<undefined>> =>
+      ipc.invoke('mongo:drop-collection', db, collection) as Promise<Result<undefined>>,
+    listConnections: (): Promise<SavedConnection[]> => ipc.invoke('connections:list') as Promise<SavedConnection[]>,
+    saveConnection: (conn: SavedConnection): Promise<void> => ipc.invoke('connections:save', conn) as Promise<void>,
+    deleteConnection: (name: string): Promise<void> => ipc.invoke('connections:delete', name) as Promise<void>,
+    getLastUsed: (): Promise<string | null> => ipc.invoke('connections:get-last-used') as Promise<string | null>,
+    setLastUsed: (uri: string): Promise<void> => ipc.invoke('connections:set-last-used', uri) as Promise<void>,
+    loadHistory: (): Promise<QueryHistoryEntry[]> => ipc.invoke('history:load') as Promise<QueryHistoryEntry[]>,
+    saveHistory: (entries: QueryHistoryEntry[]): Promise<void> => ipc.invoke('history:save', entries) as Promise<void>,
+    clearHistory: (): Promise<void> => ipc.invoke('history:clear') as Promise<void>,
+    exportCollection: (db: string, collection: string): Promise<Result<number | null>> =>
+      ipc.invoke('mongo:export-collection', db, collection) as Promise<Result<number | null>>,
+    cancelExport: (db: string, collection: string): Promise<Result<undefined>> =>
+      ipc.invoke('mongo:cancel-export', db, collection) as Promise<Result<undefined>>,
+    onExportProgress: (cb: (data: ExportProgress) => void): (() => void) => {
+      const handler = (_event: unknown, data: ExportProgress): void => cb(data);
+      ipc.on('export:progress', handler as (event: unknown, ...args: unknown[]) => void);
+      return () => ipc.off('export:progress', handler as (event: unknown, ...args: unknown[]) => void);
+    },
+    exportDatabase: (db: string): Promise<Result<number | null>> =>
+      ipc.invoke('mongo:export-database', db) as Promise<Result<number | null>>,
+    cancelExportDatabase: (db: string): Promise<Result<undefined>> =>
+      ipc.invoke('mongo:cancel-export-database', db) as Promise<Result<undefined>>,
+    onExportDbProgress: (cb: (data: ExportDbProgress) => void): (() => void) => {
+      const handler = (_event: unknown, data: ExportDbProgress): void => cb(data);
+      ipc.on('export-db:progress', handler as (event: unknown, ...args: unknown[]) => void);
+      return () => ipc.off('export-db:progress', handler as (event: unknown, ...args: unknown[]) => void);
+    },
+    pickImportFile: (): Promise<Result<PickedFile[] | null>> =>
+      ipc.invoke('mongo:pick-import-file') as Promise<Result<PickedFile[] | null>>,
+    importCollection: (
+      db: string,
+      collection: string,
+      filePath: string,
+      options: ImportOptions
+    ): Promise<Result<{ inserted: number; skipped: number } | null>> =>
+      ipc.invoke('mongo:import-collection', db, collection, filePath, options) as Promise<
+        Result<{ inserted: number; skipped: number } | null>
+      >,
+    cancelImport: (db: string, collection: string): Promise<Result<undefined>> =>
+      ipc.invoke('mongo:cancel-import', db, collection) as Promise<Result<undefined>>,
+    onImportProgress: (cb: (data: ImportProgress) => void): (() => void) => {
+      const handler = (_event: unknown, data: ImportProgress): void => cb(data);
+      ipc.on('import:progress', handler as (event: unknown, ...args: unknown[]) => void);
+      return () => ipc.off('import:progress', handler as (event: unknown, ...args: unknown[]) => void);
+    },
+  };
+}
+
+const api = createApi(ipcRenderer as unknown as IpcLike);
+
+export type MongoApi = ReturnType<typeof createApi>;
 
 if (process.contextIsolated) {
   try {
@@ -97,7 +125,7 @@ if (process.contextIsolated) {
   } catch (error) {
     console.error(error);
   }
-} else {
+} else if (typeof window !== 'undefined') {
   // @ts-expect-error (define in dts)
   window.electron = electronAPI;
   // @ts-expect-error (define in dts)

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useLayoutEffect } from 'react';
-import { useStore } from './store';
+import { useStore, selectConnected } from './store';
 import { ConnectionDialog } from './components/ConnectionDialog';
 import { Sidebar } from './components/Sidebar';
 import { DocumentTable } from './components/DocumentTable';
@@ -9,7 +9,7 @@ import { QueryHistory } from './components/QueryHistory';
 import { Toaster } from './components/ui/sonner';
 
 function App() {
-  const connected = useStore((s) => s.connected);
+  const connected = useStore(selectConnected);
   const selectedCollection = useStore((s) => s.selectedCollection);
   const [dialogOpen, setDialogOpen] = useState(!connected);
   const [editDoc, setEditDoc] = useState<Record<string, unknown> | null>(null);

--- a/src/renderer/src/components/ConnectionDialog.test.tsx
+++ b/src/renderer/src/components/ConnectionDialog.test.tsx
@@ -4,6 +4,21 @@ import userEvent from '@testing-library/user-event';
 import { ConnectionDialog } from './ConnectionDialog';
 import { useStore } from '../store';
 import { toast } from 'sonner';
+import type { ConnectedSession, ConnectionState } from '../../../shared/types';
+
+function sessionOk(uri = 'mongodb://localhost:27017'): { ok: true; data: ConnectedSession } {
+  return {
+    ok: true,
+    data: {
+      uri,
+      connectionKey: 'localhost:27017',
+      databases: [],
+      queryHistory: [],
+      autoSelectedDb: null,
+      collections: [],
+    },
+  };
+}
 
 vi.mock('sonner', () => ({
   toast: {
@@ -14,6 +29,7 @@ vi.mock('sonner', () => ({
 const mockApi = {
   connect: vi.fn(),
   disconnect: vi.fn(),
+  onConnectionState: vi.fn(() => () => {}),
   listDatabases: vi.fn(),
   listCollections: vi.fn(),
   find: vi.fn(),
@@ -31,7 +47,7 @@ const mockApi = {
 beforeEach(() => {
   vi.clearAllMocks();
   useStore.setState({
-    connected: false,
+    status: { status: 'disconnected' } as ConnectionState,
     uri: '',
     databases: [],
     collections: [],
@@ -59,9 +75,7 @@ describe('ConnectionDialog', () => {
   });
 
   it('submit calls store.connect', async () => {
-    mockApi.connect.mockResolvedValue({ ok: true, data: undefined });
-    mockApi.listDatabases.mockResolvedValue({ ok: true, data: [] });
-    mockApi.setLastUsed.mockResolvedValue(undefined);
+    mockApi.connect.mockResolvedValue(sessionOk());
 
     const onOpenChange = vi.fn();
     render(<ConnectionDialog open={true} onOpenChange={onOpenChange} />);
@@ -90,9 +104,7 @@ describe('ConnectionDialog', () => {
   });
 
   it('hides dialog on successful connection', async () => {
-    mockApi.connect.mockResolvedValue({ ok: true, data: undefined });
-    mockApi.listDatabases.mockResolvedValue({ ok: true, data: [] });
-    mockApi.setLastUsed.mockResolvedValue(undefined);
+    mockApi.connect.mockResolvedValue(sessionOk());
 
     const onOpenChange = vi.fn();
     render(<ConnectionDialog open={true} onOpenChange={onOpenChange} />);
@@ -122,9 +134,7 @@ describe('ConnectionDialog', () => {
 
   it('click saved connection fills URI and connects', async () => {
     mockApi.listConnections.mockResolvedValue([{ name: 'Local', uri: 'mongodb://localhost:27017' }]);
-    mockApi.connect.mockResolvedValue({ ok: true, data: undefined });
-    mockApi.listDatabases.mockResolvedValue({ ok: true, data: [] });
-    mockApi.setLastUsed.mockResolvedValue(undefined);
+    mockApi.connect.mockResolvedValue(sessionOk());
 
     const onOpenChange = vi.fn();
     render(<ConnectionDialog open={true} onOpenChange={onOpenChange} />);

--- a/src/renderer/src/components/ConnectionDialog.tsx
+++ b/src/renderer/src/components/ConnectionDialog.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from './ui/dialog';
 import { Button } from './ui/button';
 import { Input } from './ui/input';
-import { useStore } from '../store';
+import { useStore, selectConnected } from '../store';
 import { toast } from 'sonner';
 import { Pencil, Trash2 } from 'lucide-react';
 
@@ -36,7 +36,7 @@ export function ConnectionDialog({ open, onOpenChange }: ConnectionDialogProps) 
   const [pendingUri, setPendingUri] = useState('');
   const [pendingName, setPendingName] = useState('');
   const [authError, setAuthError] = useState<string | null>(null);
-  const connected = useStore((s) => s.connected);
+  const connected = useStore(selectConnected);
   const connect = useStore((s) => s.connect);
   const savedConnections = useStore((s) => s.savedConnections);
   const loadSavedConnections = useStore((s) => s.loadSavedConnections);

--- a/src/renderer/src/components/DocumentEditor.test.tsx
+++ b/src/renderer/src/components/DocumentEditor.test.tsx
@@ -53,7 +53,7 @@ function setEditorText(value: string): void {
 beforeEach(() => {
   vi.clearAllMocks();
   useStore.setState({
-    connected: true,
+    status: { status: 'connected', uri: 'mongodb://localhost', connectionKey: 'localhost:27017' },
     uri: 'mongodb://localhost',
     databases: [],
     collections: [],

--- a/src/renderer/src/components/DocumentTable.test.tsx
+++ b/src/renderer/src/components/DocumentTable.test.tsx
@@ -16,7 +16,7 @@ const mockApi = {
 beforeEach(() => {
   vi.clearAllMocks();
   useStore.setState({
-    connected: true,
+    status: { status: 'connected', uri: 'mongodb://localhost', connectionKey: 'localhost:27017' },
     uri: 'mongodb://localhost',
     databases: [],
     collections: [],

--- a/src/renderer/src/components/QueryEditor.test.tsx
+++ b/src/renderer/src/components/QueryEditor.test.tsx
@@ -66,7 +66,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   (window as unknown as Record<string, unknown>).api = mockApi;
   useStore.setState({
-    connected: true,
+    status: { status: 'connected', uri: 'mongodb://localhost', connectionKey: 'localhost:27017' },
     selectedDb: 'testdb',
     selectedCollection: 'users',
     docs: [],

--- a/src/renderer/src/components/Sidebar.test.tsx
+++ b/src/renderer/src/components/Sidebar.test.tsx
@@ -29,7 +29,7 @@ const mockApi = {
 beforeEach(() => {
   vi.clearAllMocks();
   useStore.setState({
-    connected: false,
+    status: { status: 'disconnected' },
     uri: '',
     databases: [],
     collections: [],
@@ -49,7 +49,7 @@ beforeEach(() => {
 describe('Sidebar', () => {
   it('renders database list', () => {
     useStore.setState({
-      connected: true,
+      status: { status: 'connected', uri: 'mongodb://localhost', connectionKey: 'localhost:27017' },
       databases: [
         { name: 'testdb', sizeOnDisk: 1024, empty: false },
         { name: 'admin', sizeOnDisk: 512, empty: false },
@@ -72,7 +72,7 @@ describe('Sidebar', () => {
     });
 
     useStore.setState({
-      connected: true,
+      status: { status: 'connected', uri: 'mongodb://localhost', connectionKey: 'localhost:27017' },
       databases: [{ name: 'testdb', sizeOnDisk: 1024, empty: false }],
     });
 
@@ -99,7 +99,7 @@ describe('Sidebar', () => {
     });
 
     useStore.setState({
-      connected: true,
+      status: { status: 'connected', uri: 'mongodb://localhost', connectionKey: 'localhost:27017' },
       databases: [{ name: 'testdb', sizeOnDisk: 1024, empty: false }],
     });
 
@@ -123,7 +123,7 @@ describe('Sidebar', () => {
 
   it('shows selected collection as active', async () => {
     useStore.setState({
-      connected: true,
+      status: { status: 'connected', uri: 'mongodb://localhost', connectionKey: 'localhost:27017' },
       databases: [{ name: 'testdb', sizeOnDisk: 1024, empty: false }],
       selectedDb: 'testdb',
       selectedCollection: 'users',

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import { useStore } from './store';
 import './assets/index.css';
+
+useStore.getState().subscribeToConnectionState();
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/src/renderer/src/store.test.ts
+++ b/src/renderer/src/store.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { useStore } from './store';
+import { useStore, selectConnected } from './store';
+import type { ConnectionState, ConnectedSession } from '../../shared/types';
 
 const mockApi = {
   connect: vi.fn(),
   disconnect: vi.fn(),
+  onConnectionState: vi.fn<(cb: (s: ConnectionState) => void) => () => void>(() => () => {}),
   listDatabases: vi.fn(),
   listCollections: vi.fn(),
   find: vi.fn(),
@@ -24,10 +26,23 @@ const mockApi = {
   distinct: vi.fn(),
 };
 
+function makeSession(overrides: Partial<ConnectedSession> = {}): ConnectedSession {
+  return {
+    uri: 'mongodb://localhost',
+    connectionKey: 'localhost:27017',
+    databases: [],
+    queryHistory: [],
+    autoSelectedDb: null,
+    collections: [],
+    ...overrides,
+  };
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
+  mockApi.onConnectionState.mockImplementation(() => () => {});
   useStore.setState({
-    connected: false,
+    status: { status: 'disconnected' } as ConnectionState,
     uri: '',
     databases: [],
     collections: [],
@@ -51,79 +66,67 @@ beforeEach(() => {
 });
 
 describe('store', () => {
-  it('connect(uri) sets connected=true and loads databases and history', async () => {
+  it('connect(uri) applies ConnectedSession atomically in one setState', async () => {
     const historyEntries = [
       { id: '1', type: 'filter' as const, query: '{}', db: 'test', collection: 'users', timestamp: 1000 },
     ];
-    mockApi.connect.mockResolvedValue({ ok: true, data: undefined });
-    mockApi.listDatabases.mockResolvedValue({
+    mockApi.connect.mockResolvedValue({
       ok: true,
-      data: [{ name: 'testdb', sizeOnDisk: 1024, empty: false }],
+      data: makeSession({
+        uri: 'mongodb://localhost',
+        connectionKey: 'localhost:27017',
+        databases: [{ name: 'testdb', sizeOnDisk: 1024, empty: false }],
+        queryHistory: historyEntries,
+        autoSelectedDb: 'testdb',
+        collections: [{ name: 'users', type: 'collection' }],
+      }),
     });
-    mockApi.listCollections.mockResolvedValue({
-      ok: true,
-      data: [{ name: 'users', type: 'collection' }],
-    });
-    mockApi.loadHistory.mockResolvedValue(historyEntries);
 
     await useStore.getState().connect('mongodb://localhost');
 
     const state = useStore.getState();
-    expect(state.connected).toBe(true);
     expect(state.uri).toBe('mongodb://localhost');
     expect(state.databases).toEqual([{ name: 'testdb', sizeOnDisk: 1024, empty: false }]);
     expect(state.queryHistory).toEqual(historyEntries);
     expect(state.selectedDb).toBe('testdb');
     expect(state.collections).toEqual([{ name: 'users', type: 'collection' }]);
     expect(mockApi.connect).toHaveBeenCalledWith('mongodb://localhost');
-    expect(mockApi.listDatabases).toHaveBeenCalled();
-    expect(mockApi.listCollections).toHaveBeenCalledWith('testdb');
-    expect(mockApi.loadHistory).toHaveBeenCalled();
+    expect(mockApi.listDatabases).not.toHaveBeenCalled();
+    expect(mockApi.listCollections).not.toHaveBeenCalled();
+    expect(mockApi.loadHistory).not.toHaveBeenCalled();
+    expect(mockApi.setLastUsed).not.toHaveBeenCalled();
   });
 
-  it('connect() does not auto-select when multiple databases exist', async () => {
-    mockApi.connect.mockResolvedValue({ ok: true, data: undefined });
-    mockApi.listDatabases.mockResolvedValue({
+  it('connect() multi-db session: autoSelectedDb null, collections empty, databases populated', async () => {
+    mockApi.connect.mockResolvedValue({
       ok: true,
-      data: [
-        { name: 'db1', sizeOnDisk: 1024, empty: false },
-        { name: 'db2', sizeOnDisk: 2048, empty: false },
-      ],
+      data: makeSession({
+        databases: [
+          { name: 'db1', sizeOnDisk: 1024, empty: false },
+          { name: 'db2', sizeOnDisk: 2048, empty: false },
+        ],
+        autoSelectedDb: null,
+        collections: [],
+      }),
     });
 
     await useStore.getState().connect('mongodb://localhost');
 
     const state = useStore.getState();
-    expect(state.connected).toBe(true);
+    expect(state.databases).toHaveLength(2);
     expect(state.selectedDb).toBeNull();
     expect(state.collections).toEqual([]);
-    expect(mockApi.listCollections).not.toHaveBeenCalled();
   });
 
-  it('connect() auto-select handles listCollections failure gracefully', async () => {
-    mockApi.connect.mockResolvedValue({ ok: true, data: undefined });
-    mockApi.listDatabases.mockResolvedValue({
-      ok: true,
-      data: [{ name: 'testdb', sizeOnDisk: 1024, empty: false }],
-    });
-    mockApi.listCollections.mockResolvedValue({ ok: false, error: 'Not authorized' });
-
-    await useStore.getState().connect('mongodb://localhost');
-
-    const state = useStore.getState();
-    expect(state.connected).toBe(true);
-    expect(state.selectedDb).toBe('testdb');
-    expect(state.collections).toEqual([]);
-  });
-
-  it('connect failure sets error, connected=false', async () => {
+  it('connect failure sets error and leaves databases empty', async () => {
     mockApi.connect.mockResolvedValue({ ok: false, error: 'Connection refused' });
 
     await useStore.getState().connect('mongodb://badhost');
 
     const state = useStore.getState();
-    expect(state.connected).toBe(false);
+    expect(selectConnected(state)).toBe(false);
     expect(state.error).toBe('Connection refused');
+    expect(state.databases).toEqual([]);
   });
 
   it('selectDb(db) loads collections', async () => {
@@ -184,12 +187,12 @@ describe('store', () => {
     });
   });
 
-  it('disconnect() resets state', async () => {
+  it('disconnect() resets derived state fields', async () => {
     mockApi.disconnect.mockResolvedValue({ ok: true, data: undefined });
 
     // Set some state first
     useStore.setState({
-      connected: true,
+      status: { status: 'connected', uri: 'mongodb://localhost', connectionKey: 'localhost:27017' },
       uri: 'mongodb://localhost',
       databases: [{ name: 'testdb', sizeOnDisk: 1024, empty: false }],
       selectedDb: 'testdb',
@@ -199,23 +202,12 @@ describe('store', () => {
     await useStore.getState().disconnect();
 
     const state = useStore.getState();
-    expect(state.connected).toBe(false);
     expect(state.uri).toBe('');
     expect(state.databases).toEqual([]);
     expect(state.selectedDb).toBeNull();
     expect(state.selectedCollection).toBeNull();
     expect(state.docs).toEqual([]);
     expect(mockApi.disconnect).toHaveBeenCalled();
-  });
-
-  it('connect(uri) calls setLastUsed on success', async () => {
-    mockApi.connect.mockResolvedValue({ ok: true, data: undefined });
-    mockApi.listDatabases.mockResolvedValue({ ok: true, data: [] });
-    mockApi.setLastUsed.mockResolvedValue(undefined);
-
-    await useStore.getState().connect('mongodb://localhost');
-
-    expect(mockApi.setLastUsed).toHaveBeenCalledWith('mongodb://localhost');
   });
 
   it('loadSavedConnections() fetches and sets savedConnections', async () => {
@@ -248,17 +240,22 @@ describe('store', () => {
     expect(useStore.getState().savedConnections).toEqual([]);
   });
 
-  it('autoReconnect() connects with last used URI', async () => {
+  it('autoReconnect() connects with last used URI and applies session', async () => {
     mockApi.getLastUsed.mockResolvedValue('mongodb://localhost:27017');
-    mockApi.connect.mockResolvedValue({ ok: true, data: undefined });
-    mockApi.listDatabases.mockResolvedValue({ ok: true, data: [] });
-    mockApi.setLastUsed.mockResolvedValue(undefined);
+    mockApi.connect.mockResolvedValue({
+      ok: true,
+      data: makeSession({
+        uri: 'mongodb://localhost:27017',
+        databases: [{ name: 'testdb', sizeOnDisk: 1024, empty: false }],
+      }),
+    });
 
     await useStore.getState().autoReconnect();
 
     expect(mockApi.getLastUsed).toHaveBeenCalled();
     expect(mockApi.connect).toHaveBeenCalledWith('mongodb://localhost:27017');
-    expect(useStore.getState().connected).toBe(true);
+    expect(useStore.getState().databases).toHaveLength(1);
+    expect(useStore.getState().uri).toBe('mongodb://localhost:27017');
   });
 
   it('autoReconnect() does nothing when no last used URI', async () => {
@@ -267,12 +264,11 @@ describe('store', () => {
     await useStore.getState().autoReconnect();
 
     expect(mockApi.connect).not.toHaveBeenCalled();
-    expect(useStore.getState().connected).toBe(false);
+    expect(selectConnected(useStore.getState())).toBe(false);
   });
 
   it('runQuery() in filter mode calls find with parsed filter', async () => {
     useStore.setState({
-      connected: true,
       selectedDb: 'testdb',
       selectedCollection: 'users',
     });
@@ -296,7 +292,6 @@ describe('store', () => {
 
   it('runQuery() in aggregate mode calls aggregate with parsed pipeline', async () => {
     useStore.setState({
-      connected: true,
       selectedDb: 'testdb',
       selectedCollection: 'users',
       queryMode: 'aggregate',
@@ -315,7 +310,6 @@ describe('store', () => {
 
   it('runQuery() adds entry to queryHistory after successful parse', async () => {
     useStore.setState({
-      connected: true,
       selectedDb: 'testdb',
       selectedCollection: 'users',
     });
@@ -336,7 +330,6 @@ describe('store', () => {
 
   it('runQuery() returns error string for invalid JSON', async () => {
     useStore.setState({
-      connected: true,
       selectedDb: 'testdb',
       selectedCollection: 'users',
     });
@@ -358,7 +351,6 @@ describe('store', () => {
 
   it('insertDoc() calls insertOne and refreshes docs', async () => {
     useStore.setState({
-      connected: true,
       selectedDb: 'testdb',
       selectedCollection: 'users',
     });
@@ -378,7 +370,6 @@ describe('store', () => {
 
   it('insertDoc() returns error on failure', async () => {
     useStore.setState({
-      connected: true,
       selectedDb: 'testdb',
       selectedCollection: 'users',
     });
@@ -391,7 +382,6 @@ describe('store', () => {
 
   it('updateDoc() calls updateOne and refreshes docs', async () => {
     useStore.setState({
-      connected: true,
       selectedDb: 'testdb',
       selectedCollection: 'users',
     });
@@ -410,7 +400,6 @@ describe('store', () => {
 
   it('deleteDoc() calls deleteOne and refreshes docs', async () => {
     useStore.setState({
-      connected: true,
       selectedDb: 'testdb',
       selectedCollection: 'users',
       docs: [{ _id: '1', name: 'Alice' }],
@@ -614,5 +603,93 @@ describe('fetchDistinct', () => {
     const result = await useStore.getState().fetchDistinct('status');
 
     expect(result).toEqual(errorResult);
+  });
+});
+
+describe('subscribeToConnectionState', () => {
+  it('subscribes to window.api.onConnectionState and updates status on emit', () => {
+    let emit: (s: ConnectionState) => void = () => {};
+    mockApi.onConnectionState.mockImplementation((cb: (s: ConnectionState) => void) => {
+      emit = cb;
+      return () => {};
+    });
+
+    useStore.getState().subscribeToConnectionState();
+
+    expect(mockApi.onConnectionState).toHaveBeenCalledTimes(1);
+
+    emit({ status: 'connecting', uri: 'mongodb://localhost' });
+    expect(useStore.getState().status).toEqual({ status: 'connecting', uri: 'mongodb://localhost' });
+
+    emit({ status: 'connected', uri: 'mongodb://localhost', connectionKey: 'localhost:27017' });
+    expect(selectConnected(useStore.getState())).toBe(true);
+
+    emit({ status: 'disconnected' });
+    expect(selectConnected(useStore.getState())).toBe(false);
+  });
+
+  it('returns an unsubscribe function that removes the listener', () => {
+    const unsubSpy = vi.fn();
+    mockApi.onConnectionState.mockImplementation(() => unsubSpy);
+
+    const unsub = useStore.getState().subscribeToConnectionState();
+    unsub();
+
+    expect(unsubSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('selectConnected', () => {
+  it('is true when status.status === connected', () => {
+    expect(
+      selectConnected({
+        status: { status: 'connected', uri: 'u', connectionKey: 'k' },
+      } as unknown as ReturnType<typeof useStore.getState>)
+    ).toBe(true);
+  });
+
+  it('is false for every other status', () => {
+    const states: ConnectionState[] = [
+      { status: 'disconnected' },
+      { status: 'connecting', uri: 'u' },
+      { status: 'error', uri: 'u', error: 'e' },
+    ];
+    for (const s of states) {
+      expect(selectConnected({ status: s } as unknown as ReturnType<typeof useStore.getState>)).toBe(false);
+    }
+  });
+});
+
+// Enforces atomicity: a "connected" assertion must be backed by a populated session
+describe('connect() atomicity invariant', () => {
+  it('populates databases together with status transitions when subscription is active', async () => {
+    let emit: (s: ConnectionState) => void = () => {};
+    mockApi.onConnectionState.mockImplementation((cb: (s: ConnectionState) => void) => {
+      emit = cb;
+      return () => {};
+    });
+    mockApi.connect.mockImplementation(async () => {
+      emit({ status: 'connecting', uri: 'mongodb://localhost' });
+      emit({ status: 'connected', uri: 'mongodb://localhost', connectionKey: 'localhost:27017' });
+      return {
+        ok: true,
+        data: {
+          uri: 'mongodb://localhost',
+          connectionKey: 'localhost:27017',
+          databases: [{ name: 'testdb', sizeOnDisk: 1024, empty: false }],
+          queryHistory: [],
+          autoSelectedDb: 'testdb',
+          collections: [{ name: 'users', type: 'collection' }],
+        } as ConnectedSession,
+      };
+    });
+
+    useStore.getState().subscribeToConnectionState();
+    await useStore.getState().connect('mongodb://localhost');
+
+    const state = useStore.getState();
+    expect(selectConnected(state)).toBe(true);
+    expect(state.databases).toHaveLength(1);
+    expect(state.collections).toHaveLength(1);
   });
 });

--- a/src/renderer/src/store.ts
+++ b/src/renderer/src/store.ts
@@ -7,10 +7,11 @@ import type {
   QueryHistoryEntry,
   DistinctResult,
   Result,
+  ConnectionState,
 } from '../../shared/types';
 
-interface StoreState {
-  connected: boolean;
+export interface StoreState {
+  status: ConnectionState;
   uri: string;
   databases: DbInfo[];
   collections: CollectionInfo[];
@@ -33,6 +34,7 @@ interface StoreState {
 
   connect: (uri: string) => Promise<void>;
   disconnect: () => Promise<void>;
+  subscribeToConnectionState: () => () => void;
   selectDb: (db: string) => Promise<void>;
   selectCollection: (db: string, collection: string) => Promise<void>;
   fetchPage: (skip: number) => Promise<void>;
@@ -56,8 +58,10 @@ interface StoreState {
   fetchDistinct: (field: string) => Promise<Result<DistinctResult> | null>;
 }
 
+export const selectConnected = (s: StoreState): boolean => s.status.status === 'connected';
+
 export const useStore = create<StoreState>()((set, get) => ({
-  connected: false,
+  status: { status: 'disconnected' },
   uri: '',
   databases: [],
   collections: [],
@@ -79,46 +83,20 @@ export const useStore = create<StoreState>()((set, get) => ({
   pendingQueryMode: null,
 
   connect: async (uri: string) => {
-    if (get().connected) {
-      await get().disconnect();
-    }
+    if (selectConnected(get())) await get().disconnect();
     set({ loading: true, error: null });
     const result = await window.api.connect(uri);
     if (!result.ok) {
-      set({ loading: false, error: result.error, connected: false });
+      set({ loading: false, error: result.error });
       return;
     }
-    const dbResult = await window.api.listDatabases();
-    if (!dbResult.ok) {
-      set({ loading: false, error: dbResult.error, connected: true, uri });
-      return;
-    }
-    await window.api.setLastUsed(uri);
-    const history = await window.api.loadHistory();
-    let autoSelectedDb: string | null = null;
-    let collections: CollectionInfo[] = [];
-    if (dbResult.data.length === 1) {
-      autoSelectedDb = dbResult.data[0].name;
-      const collResult = await window.api.listCollections(autoSelectedDb);
-      if (collResult.ok) {
-        collections = collResult.data;
-      }
-    }
-    set({
-      loading: false,
-      connected: true,
-      uri,
-      databases: dbResult.data,
-      queryHistory: history,
-      selectedDb: autoSelectedDb,
-      collections,
-    });
+    const { databases, queryHistory, autoSelectedDb, collections } = result.data;
+    set({ loading: false, uri: result.data.uri, databases, queryHistory, selectedDb: autoSelectedDb, collections });
   },
 
   disconnect: async () => {
     await window.api.disconnect();
     set({
-      connected: false,
       uri: '',
       databases: [],
       collections: [],
@@ -132,6 +110,8 @@ export const useStore = create<StoreState>()((set, get) => ({
       fieldNames: [],
     });
   },
+
+  subscribeToConnectionState: () => window.api.onConnectionState((status) => set({ status })),
 
   selectDb: async (db: string) => {
     set({ loading: true, selectedDb: db, selectedCollection: null, docs: [], totalCount: 0, fieldNames: [] });

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -72,3 +72,24 @@ export interface DistinctResult {
   values: unknown[];
   truncated: boolean;
 }
+
+export type ConnectionState =
+  | { status: 'disconnected' }
+  | { status: 'connecting'; uri: string }
+  | { status: 'connected'; uri: string; connectionKey: string }
+  | { status: 'error'; uri: string; error: string };
+
+export interface ConnectedSession {
+  uri: string;
+  connectionKey: string;
+  databases: DbInfo[];
+  queryHistory: QueryHistoryEntry[];
+  autoSelectedDb: string | null;
+  collections: CollectionInfo[];
+}
+
+export interface ConnectOptions {
+  autoSelectSingleDb?: boolean;
+  persistAsLastUsed?: boolean;
+  loadHistory?: boolean;
+}

--- a/vitest.config.main.ts
+++ b/vitest.config.main.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     environment: 'node',
-    include: ['src/main/**/*.test.ts'],
+    include: ['src/main/**/*.test.ts', 'src/preload/**/*.test.ts'],
     globals: true
   }
 })


### PR DESCRIPTION
### What does this PR do?

## Problem

Connection identity is fragmented across three independently-mutated places:

- `MongoService.client` (main) — the real driver handle, guarded by 14 `if (!this.client)` preludes in `src/main/mongo-service.ts`
- `ipc-handlers.ts` module-level `currentUri` (line 32) — feeds history keying only; never reconciled with the service's actual state
- `useStore.connected` + `useStore.uri` (renderer, `src/renderer/src/store.ts:81-116`) — set after a 4-call chain (`connect → listDatabases → setLastUsed → loadHistory → [listCollections]`) that can partially fail

### Concrete bugs this enables

- Mid-chain failure in `store.ts:93` leaves `connected: true` with no databases (user sees a blank UI).
- Rapid `connect(A)` then `connect(B)` isn't atomic — the 4-call chain for A can interleave with B.
- `autoReconnect()` (store.ts:417) races with manual connect on `currentUri`.
- No `connecting` status — UI can't disable itself during a connect.
- History keys off a mutable `currentUri` that's set independently of the actual live connection.

### Changes

- [x] #17 ConnectionManager: build module with TDD (red → green)
- [x] #18 MongoService: constructor injection + requireClient()
- [x] #19 ipc-handlers: route connect/disconnect + history through ConnectionManager
- [x] #20 Preload: extend surface with ConnectedSession + onConnectionState
- [x] #21 Renderer store: collapse connect, subscribe to connection:state
- [x] #22 Wire main/index.ts + final verification (lint, test, smoke)

### Related issues

Closes #14

### How to test



### Additional notes

Generated by [Ralph Issues](https://github.com/richtabor/agent-skills).