### PR TITLE
Embed read-only MCP server in mongo-buddy

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@codemirror/view": "6.40.0",
     "@electron-toolkit/preload": "3.0.2",
     "@electron-toolkit/utils": "4.0.0",
+    "@modelcontextprotocol/sdk": "1.29.0",
     "bson": "7.2.0",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
@@ -50,6 +51,7 @@
     "react-dom": "19.2.4",
     "sonner": "2.0.7",
     "tailwind-merge": "3.5.0",
+    "zod": "4.3.6",
     "zustand": "5.0.12"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@electron-toolkit/utils':
         specifier: 4.0.0
         version: 4.0.0(electron@41.1.0)
+      '@modelcontextprotocol/sdk':
+        specifier: 1.29.0
+        version: 1.29.0(zod@4.3.6)
       bson:
         specifier: 7.2.0
         version: 7.2.0
@@ -80,6 +83,9 @@ importers:
       tailwind-merge:
         specifier: 3.5.0
         version: 3.5.0
+      zod:
+        specifier: 4.3.6
+        version: 4.3.6
       zustand:
         specifier: 5.0.12
         version: 5.0.12(@types/react@19.2.14)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
@@ -815,6 +821,12 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -888,6 +900,16 @@ packages:
 
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@mongodb-js/saslprep@1.4.6':
     resolution: {integrity: sha512-y+x3H1xBZd38n10NZF/rEBlvDOOMQ6LKUTHqr8R9VkJ+mmQOYtJFxIlkkK8fZrtOiL6VixbOBWMbZGBdal3Z1g==}
@@ -1378,6 +1400,10 @@ packages:
     resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1547,6 +1573,10 @@ packages:
   bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
 
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
   boolean@3.2.0:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
@@ -1597,6 +1627,10 @@ packages:
   builder-util@26.8.1:
     resolution: {integrity: sha512-pm1lTYbGyc90DHgCDO7eo8Rl4EqKLciayNbZqGziqnH9jrlKe8ZANGdityLZU+pJh16dfzjAx2xQq9McuIPEtw==}
 
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
@@ -1615,6 +1649,10 @@ packages:
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
   camelcase-keys@6.2.2:
@@ -1750,6 +1788,14 @@ packages:
   config-file-ts@0.2.6:
     resolution: {integrity: sha512-6boGVaglwblBgJqGyxm4+xCmEGcWgnWHSWHY5jad58awQhB6gftq0G8HbzU39YqCIYHMLAiL1yjwiZ36m/CL8w==}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
   conventional-changelog-angular@6.0.0:
     resolution: {integrity: sha512-6qLgrBF4gueoC7AFVHu51nHL9pF9FRjXrH+ceVf7WmAfH3gs+gEYOkvxhjMPjZu57I4AGUGoNTY8V7Hrgf1uqg==}
     engines: {node: '>=14'}
@@ -1823,11 +1869,23 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
   core-util-is@1.0.2:
     resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   crc-32@1.2.2:
     resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
@@ -1919,6 +1977,10 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -1993,6 +2055,9 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   ejs@3.1.10:
     resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
     engines: {node: '>=0.10.0'}
@@ -2040,6 +2105,10 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   encoding@0.1.13:
     resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
@@ -2104,6 +2173,9 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
@@ -2189,12 +2261,34 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
+
+  express-rate-limit@8.4.1:
+    resolution: {integrity: sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   extract-zip@2.0.1:
     resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
@@ -2250,6 +2344,10 @@ packages:
   filelist@1.0.6:
     resolution: {integrity: sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-up@2.1.0:
     resolution: {integrity: sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==}
     engines: {node: '>=4'}
@@ -2280,6 +2378,14 @@ packages:
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -2433,6 +2539,10 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
+  hono@4.12.15:
+    resolution: {integrity: sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==}
+    engines: {node: '>=16.9.0'}
+
   hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
 
@@ -2446,6 +2556,10 @@ packages:
 
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
 
   http-proxy-agent@5.0.0:
     resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
@@ -2474,6 +2588,10 @@ packages:
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
@@ -2508,6 +2626,10 @@ packages:
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
     engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
@@ -2547,6 +2669,9 @@ packages:
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
   is-text-path@1.0.1:
     resolution: {integrity: sha512-xFuJpne9oFz5qDaodwmmG08e3CawH/2ZV8Qqza1Ko7Sk8POWbkRdwIoAWVhqvq0XeUzANEhKo2n0IXUGBm7A/w==}
     engines: {node: '>=0.10.0'}
@@ -2584,6 +2709,9 @@ packages:
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
+
+  jose@6.2.2:
+    resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2838,6 +2966,10 @@ packages:
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
   memory-pager@1.5.0:
     resolution: {integrity: sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==}
 
@@ -2845,13 +2977,25 @@ packages:
     resolution: {integrity: sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==}
     engines: {node: '>=10'}
 
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
     engines: {node: '>= 0.6'}
 
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mime@2.6.0:
     resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
@@ -3036,12 +3180,24 @@ packages:
     resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
     engines: {node: '>=10'}
 
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
   object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -3116,6 +3272,10 @@ packages:
   parse5@8.0.0:
     resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-exists@3.0.0:
     resolution: {integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==}
     engines: {node: '>=4'}
@@ -3142,6 +3302,9 @@ packages:
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   path-type@3.0.0:
     resolution: {integrity: sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==}
@@ -3171,6 +3334,10 @@ packages:
   pify@3.0.0:
     resolution: {integrity: sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==}
     engines: {node: '>=4'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   plist@3.1.0:
     resolution: {integrity: sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==}
@@ -3215,12 +3382,20 @@ packages:
   proper-lockfile@4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+    engines: {node: '>=0.6'}
 
   quick-lru@4.0.1:
     resolution: {integrity: sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==}
@@ -3229,6 +3404,14 @@ packages:
   quick-lru@5.1.1:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   react-dom@19.2.4:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
@@ -3327,6 +3510,10 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
@@ -3366,9 +3553,20 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
   serialize-error@7.0.1:
     resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
     engines: {node: '>=10'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -3377,6 +3575,22 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -3459,6 +3673,10 @@ packages:
   stat-mode@1.0.0:
     resolution: {integrity: sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==}
     engines: {node: '>= 6'}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
@@ -3603,6 +3821,10 @@ packages:
     resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
     engines: {node: '>=14.14'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   tough-cookie@6.0.1:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
@@ -3651,6 +3873,10 @@ packages:
   type-fest@5.5.0:
     resolution: {integrity: sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==}
     engines: {node: '>=20'}
+
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
 
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
@@ -3707,6 +3933,10 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -3729,6 +3959,10 @@ packages:
 
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   verror@1.10.1:
     resolution: {integrity: sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==}
@@ -3935,6 +4169,11 @@ packages:
   zip-stream@4.1.1:
     resolution: {integrity: sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==}
     engines: {node: '>= 10'}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
 
   zod-validation-error@4.0.2:
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
@@ -4574,6 +4813,10 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
+  '@hono/node-server@1.19.14(hono@4.12.15)':
+    dependencies:
+      hono: 4.12.15
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -4659,6 +4902,28 @@ snapshots:
       - supports-color
 
   '@marijn/find-cluster-break@1.0.2': {}
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.15)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.8
+      express: 5.2.1
+      express-rate-limit: 8.4.1(express@5.2.1)
+      hono: 4.12.15
+      jose: 6.2.2
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+    transitivePeerDependencies:
+      - supports-color
 
   '@mongodb-js/saslprep@1.4.6':
     dependencies:
@@ -5129,6 +5394,11 @@ snapshots:
 
   abbrev@3.0.1: {}
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -5357,6 +5627,20 @@ snapshots:
 
   bluebird@3.7.2: {}
 
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.1
+      raw-body: 3.0.2
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   boolean@3.2.0:
     optional: true
 
@@ -5450,6 +5734,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  bytes@3.1.2: {}
+
   cac@6.7.14: {}
 
   cacache@19.0.1:
@@ -5483,6 +5769,11 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   camelcase-keys@6.2.2:
     dependencies:
@@ -5641,6 +5932,10 @@ snapshots:
       glob: 10.5.0
       typescript: 5.9.3
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
   conventional-changelog-angular@6.0.0:
     dependencies:
       compare-func: 2.0.0
@@ -5731,10 +6026,19 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
   core-util-is@1.0.2:
     optional: true
 
   core-util-is@1.0.3: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   crc-32@1.2.2: {}
 
@@ -5821,6 +6125,8 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
+  depd@2.0.0: {}
+
   dequal@2.0.3: {}
 
   detect-indent@6.1.0: {}
@@ -5901,6 +6207,8 @@ snapshots:
       gopd: 1.2.0
 
   eastasianwidth@0.2.0: {}
+
+  ee-first@1.1.1: {}
 
   ejs@3.1.10:
     dependencies:
@@ -5987,6 +6295,8 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  encodeurl@2.0.0: {}
 
   encoding@0.1.13:
     dependencies:
@@ -6094,6 +6404,8 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-html@1.0.3: {}
+
   escape-string-regexp@1.0.5: {}
 
   escape-string-regexp@4.0.0: {}
@@ -6196,9 +6508,55 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  etag@1.8.1: {}
+
+  eventsource-parser@3.0.8: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.8
+
   expect-type@1.3.0: {}
 
   exponential-backoff@3.1.3: {}
+
+  express-rate-limit@8.4.1(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.1.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.1
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   extract-zip@2.0.1:
     dependencies:
@@ -6253,6 +6611,17 @@ snapshots:
     dependencies:
       minimatch: 5.1.9
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-up@2.1.0:
     dependencies:
       locate-path: 2.0.0
@@ -6290,6 +6659,10 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.2
       mime-types: 2.1.35
+
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
 
   fs-constants@1.0.0: {}
 
@@ -6478,6 +6851,8 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
+  hono@4.12.15: {}
+
   hosted-git-info@2.8.9: {}
 
   hosted-git-info@4.1.0:
@@ -6491,6 +6866,14 @@ snapshots:
       - '@noble/hashes'
 
   http-cache-semantics@4.2.0: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
 
   http-proxy-agent@5.0.0:
     dependencies:
@@ -6536,6 +6919,10 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
+
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
@@ -6556,6 +6943,8 @@ snapshots:
   ini@1.3.8: {}
 
   ip-address@10.1.0: {}
+
+  ipaddr.js@1.9.1: {}
 
   is-arrayish@0.2.1: {}
 
@@ -6582,6 +6971,8 @@ snapshots:
   is-plain-obj@1.1.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
+
+  is-promise@4.0.0: {}
 
   is-text-path@1.0.1:
     dependencies:
@@ -6612,6 +7003,8 @@ snapshots:
       picocolors: 1.1.1
 
   jiti@2.6.1: {}
+
+  jose@6.2.2: {}
 
   js-tokens@4.0.0: {}
 
@@ -6842,6 +7235,8 @@ snapshots:
 
   mdn-data@2.27.1: {}
 
+  media-typer@1.1.0: {}
+
   memory-pager@1.5.0: {}
 
   meow@8.1.2:
@@ -6858,11 +7253,19 @@ snapshots:
       type-fest: 0.18.1
       yargs-parser: 20.2.9
 
+  merge-descriptors@2.0.0: {}
+
   mime-db@1.52.0: {}
+
+  mime-db@1.54.0: {}
 
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   mime@2.6.0: {}
 
@@ -7018,10 +7421,18 @@ snapshots:
 
   normalize-url@6.1.0: {}
 
+  object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
+
   object-keys@1.1.1:
     optional: true
 
   obug@2.1.1: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
 
   once@1.4.0:
     dependencies:
@@ -7106,6 +7517,8 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  parseurl@1.3.3: {}
+
   path-exists@3.0.0: {}
 
   path-exists@4.0.0: {}
@@ -7122,6 +7535,8 @@ snapshots:
     dependencies:
       lru-cache: 10.4.3
       minipass: 7.1.3
+
+  path-to-regexp@8.4.2: {}
 
   path-type@3.0.0:
     dependencies:
@@ -7140,6 +7555,8 @@ snapshots:
   pify@2.3.0: {}
 
   pify@3.0.0: {}
+
+  pkce-challenge@5.0.1: {}
 
   plist@3.1.0:
     dependencies:
@@ -7184,6 +7601,11 @@ snapshots:
       retry: 0.12.0
       signal-exit: 3.0.7
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
@@ -7191,9 +7613,22 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  qs@6.15.1:
+    dependencies:
+      side-channel: 1.1.0
+
   quick-lru@4.0.1: {}
 
   quick-lru@5.1.1: {}
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
 
   react-dom@19.2.4(react@19.2.4):
     dependencies:
@@ -7340,6 +7775,16 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.0
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   safe-buffer@5.1.2: {}
 
   safe-buffer@5.2.1: {}
@@ -7367,16 +7812,71 @@ snapshots:
 
   semver@7.7.4: {}
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   serialize-error@7.0.1:
     dependencies:
       type-fest: 0.13.1
     optional: true
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.2.0: {}
 
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
 
@@ -7460,6 +7960,8 @@ snapshots:
   stackback@0.0.2: {}
 
   stat-mode@1.0.0: {}
+
+  statuses@2.0.2: {}
 
   std-env@4.0.0: {}
 
@@ -7605,6 +8107,8 @@ snapshots:
 
   tmp@0.2.5: {}
 
+  toidentifier@1.0.1: {}
+
   tough-cookie@6.0.1:
     dependencies:
       tldts: 7.0.27
@@ -7643,6 +8147,12 @@ snapshots:
   type-fest@5.5.0:
     dependencies:
       tagged-tag: 1.0.0
+
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
 
   typedarray@0.0.6: {}
 
@@ -7684,6 +8194,8 @@ snapshots:
 
   universalify@2.0.1: {}
 
+  unpipe@1.0.0: {}
+
   update-browserslist-db@1.2.3(browserslist@4.28.1):
     dependencies:
       browserslist: 4.28.1
@@ -7706,6 +8218,8 @@ snapshots:
     dependencies:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
+
+  vary@1.1.2: {}
 
   verror@1.10.1:
     dependencies:
@@ -7873,6 +8387,10 @@ snapshots:
       archiver-utils: 3.0.4
       compress-commons: 4.1.2
       readable-stream: 3.6.2
+
+  zod-to-json-schema@3.25.2(zod@4.3.6):
+    dependencies:
+      zod: 4.3.6
 
   zod-validation-error@4.0.2(zod@4.3.6):
     dependencies:

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -13,6 +13,8 @@ import { registerIpcHandlers } from './ipc-handlers';
 import { createOperationRegistry } from './operation-registry';
 import { createFsSinkAdapter } from './adapters/fs-sink';
 import { createDialogProviderAdapter } from './adapters/dialog-provider';
+import { parseMcpArgs } from './mcp/cli-args';
+import { startMcpServer, type McpServerHandle } from './mcp/server';
 
 const connectionStore = new ConnectionStore();
 const queryHistoryStore = new QueryHistoryStore();
@@ -23,6 +25,8 @@ const connectionManager = createConnectionManager({
   connectionKeyFromUri,
 });
 const mongoService = new MongoService({ conn: connectionManager });
+const mcpArgs = parseMcpArgs(process.argv);
+let mcpHandle: McpServerHandle | null = null;
 const broadcast = (channel: string, payload: unknown): void => {
   for (const w of BrowserWindow.getAllWindows()) {
     w.webContents.send(channel, payload);
@@ -75,7 +79,7 @@ function createWindow(): void {
   }
 }
 
-app.whenReady().then(() => {
+app.whenReady().then(async () => {
   electronApp.setAppUserModelId('com.mongobuddy');
 
   app.on('browser-window-created', (_, window) => {
@@ -89,6 +93,27 @@ app.whenReady().then(() => {
   app.on('activate', function () {
     if (BrowserWindow.getAllWindows().length === 0) createWindow();
   });
+
+  if (mcpArgs.enabled) {
+    mcpHandle = await startMcpServer({ service: mongoService, port: mcpArgs.port });
+    if (mcpHandle) {
+      console.log(`MCP server listening on http://${mcpHandle.address}:${mcpHandle.actualPort}/mcp`);
+    } else {
+      console.error(`MCP failed to bind port ${mcpArgs.port}: see earlier error`);
+    }
+  } else {
+    console.log('MCP server disabled');
+  }
+});
+
+app.on('before-quit', () => {
+  const handle = mcpHandle;
+  mcpHandle = null;
+  if (handle) {
+    void handle.close().catch((err) => {
+      console.error('MCP: error during shutdown:', err);
+    });
+  }
 });
 
 app.on('window-all-closed', () => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -15,6 +15,7 @@ import { createFsSinkAdapter } from './adapters/fs-sink';
 import { createDialogProviderAdapter } from './adapters/dialog-provider';
 import { parseMcpArgs } from './mcp/cli-args';
 import { startMcpServer, type McpServerHandle } from './mcp/server';
+import { createMcpStatusEmitter } from './mcp/status';
 
 const connectionStore = new ConnectionStore();
 const queryHistoryStore = new QueryHistoryStore();
@@ -26,6 +27,7 @@ const connectionManager = createConnectionManager({
 });
 const mongoService = new MongoService({ conn: connectionManager });
 const mcpArgs = parseMcpArgs(process.argv);
+const mcpStatusEmitter = createMcpStatusEmitter();
 let mcpHandle: McpServerHandle | null = null;
 const broadcast = (channel: string, payload: unknown): void => {
   for (const w of BrowserWindow.getAllWindows()) {
@@ -48,6 +50,7 @@ registerIpcHandlers({
   historyStore: queryHistoryStore,
   manager: connectionManager,
   registry: operationRegistry,
+  mcpStatus: mcpStatusEmitter,
   broadcast,
 });
 
@@ -98,6 +101,7 @@ app.whenReady().then(async () => {
     mcpHandle = await startMcpServer({ service: mongoService, port: mcpArgs.port });
     if (mcpHandle) {
       console.log(`MCP server listening on http://${mcpHandle.address}:${mcpHandle.actualPort}/mcp`);
+      mcpStatusEmitter.set({ running: true, port: mcpHandle.actualPort });
     } else {
       console.error(`MCP failed to bind port ${mcpArgs.port}: see earlier error`);
     }
@@ -110,6 +114,7 @@ app.on('before-quit', () => {
   const handle = mcpHandle;
   mcpHandle = null;
   if (handle) {
+    mcpStatusEmitter.set({ running: false, port: null });
     void handle.close().catch((err) => {
       console.error('MCP: error during shutdown:', err);
     });

--- a/src/main/ipc-handlers.test.ts
+++ b/src/main/ipc-handlers.test.ts
@@ -61,6 +61,12 @@ describe('IPC Handlers', () => {
   };
   let mockBroadcast: ReturnType<typeof vi.fn<Broadcast>>;
   let stateChangeCb: ((s: ConnectionState) => void) | null;
+  let mcpStatusCb: ((s: import('../shared/types').McpStatus) => void) | null;
+  let mockMcpStatus: {
+    get: ReturnType<typeof vi.fn>;
+    set: ReturnType<typeof vi.fn>;
+    subscribe: ReturnType<typeof vi.fn>;
+  };
   let mockRegistry: {
     start: ReturnType<typeof vi.fn>;
     cancel: ReturnType<typeof vi.fn>;
@@ -121,6 +127,18 @@ describe('IPC Handlers', () => {
       subscribe: vi.fn(),
     };
 
+    mcpStatusCb = null;
+    mockMcpStatus = {
+      get: vi.fn(() => ({ running: false, port: null })),
+      set: vi.fn(),
+      subscribe: vi.fn((cb: (s: import('../shared/types').McpStatus) => void) => {
+        mcpStatusCb = cb;
+        return () => {
+          mcpStatusCb = null;
+        };
+      }),
+    };
+
     handlers = {};
     vi.mocked(ipcMain.handle).mockImplementation(((channel: string, handler: (...args: unknown[]) => unknown) => {
       handlers[channel] = handler;
@@ -132,12 +150,17 @@ describe('IPC Handlers', () => {
       historyStore: mockHistoryStore as unknown as QueryHistoryStore,
       manager: mockManager as unknown as ConnectionManager,
       registry: mockRegistry as unknown as OperationRegistry,
+      mcpStatus: mockMcpStatus as unknown as import('./mcp/status').McpStatusEmitter,
       broadcast: mockBroadcast,
     });
   });
 
   afterEach(() => {
     vi.clearAllMocks();
+  });
+
+  it('registers mcp:status:get channel', () => {
+    expect(handlers['mcp:status:get']).toBeDefined();
   });
 
   it('registers all expected channels', () => {
@@ -415,6 +438,26 @@ describe('IPC Handlers', () => {
       stateChangeCb!(connected);
       expect(mockBroadcast).toHaveBeenNthCalledWith(1, 'connection:state', connecting);
       expect(mockBroadcast).toHaveBeenNthCalledWith(2, 'connection:state', connected);
+    });
+  });
+
+  describe('mcp:status', () => {
+    it('mcp:status:get returns current status from emitter', () => {
+      mockMcpStatus.get.mockReturnValue({ running: true, port: 27099 });
+      const result = handlers['mcp:status:get']({} as Electron.IpcMainInvokeEvent);
+      expect(result).toEqual({ running: true, port: 27099 });
+    });
+
+    it('subscribes to mcpStatus.subscribe on registration', () => {
+      expect(mockMcpStatus.subscribe).toHaveBeenCalledTimes(1);
+      expect(mcpStatusCb).toBeTypeOf('function');
+    });
+
+    it('broadcasts mcp:status:update on every status change', () => {
+      mcpStatusCb!({ running: true, port: 27099 });
+      mcpStatusCb!({ running: false, port: null });
+      expect(mockBroadcast).toHaveBeenCalledWith('mcp:status:update', { running: true, port: 27099 });
+      expect(mockBroadcast).toHaveBeenCalledWith('mcp:status:update', { running: false, port: null });
     });
   });
 

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -5,6 +5,7 @@ import type { ConnectionStore } from './connection-store';
 import type { ConnectionManager, ConnectOptions } from './connection-manager';
 import type { QueryHistoryStore } from './query-history-store';
 import type { OperationRegistry } from './operation-registry';
+import type { McpStatusEmitter } from './mcp/status';
 import type {
   Result,
   FindOpts,
@@ -13,6 +14,7 @@ import type {
   PickedFile,
   OperationParams,
   OperationId,
+  McpStatus,
 } from '../shared/types';
 
 export type Broadcast = (channel: string, payload: unknown) => void;
@@ -23,11 +25,12 @@ export interface IpcDeps {
   historyStore: QueryHistoryStore;
   manager: ConnectionManager;
   registry: OperationRegistry;
+  mcpStatus: McpStatusEmitter;
   broadcast?: Broadcast;
 }
 
 export function registerIpcHandlers(deps: IpcDeps): void {
-  const { service, connStore, historyStore, manager, registry, broadcast = () => {} } = deps;
+  const { service, connStore, historyStore, manager, registry, mcpStatus, broadcast = () => {} } = deps;
 
   const wrap = <T>(fn: (...args: unknown[]) => Promise<Result<T>>) => {
     return async (_event: Electron.IpcMainInvokeEvent, ...args: unknown[]): Promise<Result<T>> => {
@@ -48,6 +51,15 @@ export function registerIpcHandlers(deps: IpcDeps): void {
   manager.onStateChange((state) => {
     broadcast('connection:state', state);
   });
+
+  mcpStatus.subscribe((status) => {
+    broadcast('mcp:status:update', status);
+  });
+
+  ipcMain.handle(
+    'mcp:status:get',
+    wrapSync((): McpStatus => mcpStatus.get())
+  );
 
   ipcMain.handle(
     'mongo:connect',

--- a/src/main/mcp/cli-args.test.ts
+++ b/src/main/mcp/cli-args.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { parseMcpArgs, DEFAULT_MCP_PORT } from './cli-args';
+
+describe('parseMcpArgs', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('returns disabled with default port when no flags provided', () => {
+    expect(parseMcpArgs([])).toEqual({ enabled: false, port: DEFAULT_MCP_PORT });
+  });
+
+  it('DEFAULT_MCP_PORT is 27099', () => {
+    expect(DEFAULT_MCP_PORT).toBe(27099);
+  });
+
+  it('enables MCP with default port when --mcp is provided', () => {
+    expect(parseMcpArgs(['--mcp'])).toEqual({ enabled: true, port: 27099 });
+  });
+
+  it('enables MCP with custom port when --mcp-port=N is provided', () => {
+    expect(parseMcpArgs(['--mcp-port=3000'])).toEqual({ enabled: true, port: 3000 });
+  });
+
+  it('handles both --mcp and --mcp-port together', () => {
+    expect(parseMcpArgs(['--mcp', '--mcp-port=12345'])).toEqual({ enabled: true, port: 12345 });
+  });
+
+  it('handles flags in either order', () => {
+    expect(parseMcpArgs(['--mcp-port=12345', '--mcp'])).toEqual({ enabled: true, port: 12345 });
+  });
+
+  it('ignores unrelated argv entries and electron runtime args', () => {
+    const argv = ['/path/to/electron', '/path/to/app', '--some-electron-flag', '--mcp', '--mcp-port=8080', 'extra'];
+    expect(parseMcpArgs(argv)).toEqual({ enabled: true, port: 8080 });
+  });
+
+  it('falls back to default port and warns when --mcp-port is NaN', () => {
+    const result = parseMcpArgs(['--mcp', '--mcp-port=abc']);
+    expect(result).toEqual({ enabled: true, port: DEFAULT_MCP_PORT });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to default port and warns when --mcp-port is empty', () => {
+    const result = parseMcpArgs(['--mcp', '--mcp-port=']);
+    expect(result).toEqual({ enabled: true, port: DEFAULT_MCP_PORT });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to default port and warns when --mcp-port is zero', () => {
+    const result = parseMcpArgs(['--mcp-port=0']);
+    expect(result).toEqual({ enabled: true, port: DEFAULT_MCP_PORT });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to default port and warns when --mcp-port is negative', () => {
+    const result = parseMcpArgs(['--mcp-port=-5']);
+    expect(result).toEqual({ enabled: true, port: DEFAULT_MCP_PORT });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to default port and warns when --mcp-port exceeds 65535', () => {
+    const result = parseMcpArgs(['--mcp-port=70000']);
+    expect(result).toEqual({ enabled: true, port: DEFAULT_MCP_PORT });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to default port and warns when --mcp-port is a float', () => {
+    const result = parseMcpArgs(['--mcp-port=3000.5']);
+    expect(result).toEqual({ enabled: true, port: DEFAULT_MCP_PORT });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats --mcp-port alone (without --mcp) as enabling MCP', () => {
+    expect(parseMcpArgs(['--mcp-port=3000'])).toEqual({ enabled: true, port: 3000 });
+  });
+
+  it('accepts the minimum valid port 1', () => {
+    expect(parseMcpArgs(['--mcp-port=1'])).toEqual({ enabled: true, port: 1 });
+  });
+
+  it('accepts the maximum valid port 65535', () => {
+    expect(parseMcpArgs(['--mcp-port=65535'])).toEqual({ enabled: true, port: 65535 });
+  });
+});

--- a/src/main/mcp/cli-args.ts
+++ b/src/main/mcp/cli-args.ts
@@ -1,0 +1,42 @@
+export const DEFAULT_MCP_PORT = 27099;
+
+export interface McpArgs {
+  enabled: boolean;
+  port: number;
+}
+
+const MCP_FLAG = '--mcp';
+const MCP_PORT_PREFIX = '--mcp-port=';
+
+function parsePort(raw: string): number | null {
+  if (raw.length === 0) return null;
+  if (!/^-?\d+$/.test(raw)) return null;
+  const n = Number(raw);
+  if (!Number.isInteger(n)) return null;
+  if (n < 1 || n > 65535) return null;
+  return n;
+}
+
+export function parseMcpArgs(argv: readonly string[]): McpArgs {
+  let enabled = false;
+  let port = DEFAULT_MCP_PORT;
+
+  for (const arg of argv) {
+    if (arg === MCP_FLAG) {
+      enabled = true;
+      continue;
+    }
+    if (arg.startsWith(MCP_PORT_PREFIX)) {
+      enabled = true;
+      const raw = arg.slice(MCP_PORT_PREFIX.length);
+      const parsed = parsePort(raw);
+      if (parsed === null) {
+        console.warn(`Invalid --mcp-port value "${raw}". Falling back to default port ${DEFAULT_MCP_PORT}.`);
+      } else {
+        port = parsed;
+      }
+    }
+  }
+
+  return { enabled, port };
+}

--- a/src/main/mcp/server.test.ts
+++ b/src/main/mcp/server.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { createServer as createHttpServer, type Server } from 'node:http';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { startMcpServer } from './server';
+import type { MongoService } from '../mongo-service';
+
+const EXPECTED_TOOL_NAMES = [
+  'aggregate',
+  'count',
+  'distinct',
+  'find',
+  'list_collections',
+  'list_databases',
+  'sample_fields',
+].sort();
+
+function mockService(): MongoService {
+  return {} as MongoService;
+}
+
+async function listenBlocker(): Promise<{ server: Server; port: number }> {
+  const server = createHttpServer();
+  await new Promise<void>((res) => server.listen(0, '127.0.0.1', () => res()));
+  const addr = server.address();
+  if (!addr || typeof addr === 'string') {
+    throw new Error('blocker: unexpected address()');
+  }
+  return { server, port: addr.port };
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((res) => server.close(() => res()));
+}
+
+describe('startMcpServer', () => {
+  const restore: Array<() => Promise<void> | void> = [];
+
+  afterEach(async () => {
+    while (restore.length > 0) {
+      const fn = restore.pop();
+      if (fn) await fn();
+    }
+  });
+
+  it('round-trips initialize + tools/list and returns all 7 tool names', async () => {
+    const handle = await startMcpServer({ service: mockService(), port: 0 });
+    expect(handle).not.toBeNull();
+    if (!handle) return;
+    restore.push(() => handle.close());
+
+    expect(handle.actualPort).toBeGreaterThan(0);
+    expect(handle.address).toBe('127.0.0.1');
+
+    const url = new URL(`http://127.0.0.1:${handle.actualPort}/mcp`);
+    const client = new Client({ name: 'mongo-buddy-test', version: '0.0.0' });
+    const transport = new StreamableHTTPClientTransport(url);
+    await client.connect(transport);
+    restore.push(() => client.close());
+
+    const listed = await client.listTools();
+    const names = listed.tools.map((t) => t.name).sort();
+    expect(names).toEqual(EXPECTED_TOOL_NAMES);
+  });
+
+  it('returns null when the port is already in use (does not throw)', async () => {
+    const blocker = await listenBlocker();
+    restore.push(() => closeServer(blocker.server));
+
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    restore.push(() => errSpy.mockRestore());
+
+    const handle = await startMcpServer({ service: mockService(), port: blocker.port });
+    expect(handle).toBeNull();
+    expect(errSpy).toHaveBeenCalled();
+  });
+
+  it('close() stops accepting connections', async () => {
+    const handle = await startMcpServer({ service: mockService(), port: 0 });
+    if (!handle) throw new Error('expected handle');
+    const port = handle.actualPort;
+    await handle.close();
+
+    // Fetching the closed port should fail with a connection error.
+    await expect(fetch(`http://127.0.0.1:${port}/mcp`, { method: 'POST' })).rejects.toThrow();
+  });
+});

--- a/src/main/mcp/server.ts
+++ b/src/main/mcp/server.ts
@@ -1,0 +1,98 @@
+import { createServer as createHttpServer, type Server, type IncomingMessage, type ServerResponse } from 'node:http';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { registerMcpTools } from './tools';
+import type { MongoService } from '../mongo-service';
+
+const HOST = '127.0.0.1';
+const MCP_PATH = '/mcp';
+
+export interface StartMcpServerOptions {
+  service: MongoService;
+  port: number;
+}
+
+export interface McpServerHandle {
+  close: () => Promise<void>;
+  actualPort: number;
+  address: string;
+}
+
+async function listen(httpServer: Server, port: number): Promise<{ port: number; address: string } | null> {
+  return new Promise((resolve) => {
+    const onError = (err: NodeJS.ErrnoException): void => {
+      httpServer.removeListener('listening', onListening);
+      if (err.code === 'EADDRINUSE') {
+        console.error(`MCP: port ${port} is already in use, not starting MCP server`);
+      } else {
+        console.error('MCP: failed to bind HTTP server:', err);
+      }
+      resolve(null);
+    };
+    const onListening = (): void => {
+      httpServer.removeListener('error', onError);
+      const info = httpServer.address();
+      if (!info || typeof info === 'string') {
+        resolve(null);
+        return;
+      }
+      resolve({ port: info.port, address: info.address });
+    };
+    httpServer.once('error', onError);
+    httpServer.once('listening', onListening);
+    httpServer.listen(port, HOST);
+  });
+}
+
+export async function startMcpServer(options: StartMcpServerOptions): Promise<McpServerHandle | null> {
+  const httpServer = createHttpServer(async (req: IncomingMessage, res: ServerResponse) => {
+    const url = req.url ?? '';
+    const pathname = url.split('?')[0];
+    if (pathname !== MCP_PATH) {
+      res.statusCode = 404;
+      res.setHeader('content-type', 'text/plain');
+      res.end('Not Found');
+      return;
+    }
+
+    const mcpServer = new McpServer({ name: 'mongo-buddy', version: '1.0.0' }, { capabilities: { tools: {} } });
+    registerMcpTools(mcpServer, options.service);
+    const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+
+    const cleanup = (): void => {
+      void transport.close().catch(() => undefined);
+      void mcpServer.close().catch(() => undefined);
+    };
+    res.on('close', cleanup);
+
+    try {
+      await mcpServer.connect(transport);
+      await transport.handleRequest(req, res);
+    } catch (err) {
+      console.error('MCP: request handler error:', err);
+      if (!res.headersSent) {
+        res.statusCode = 500;
+        res.setHeader('content-type', 'application/json');
+        res.end(JSON.stringify({ jsonrpc: '2.0', error: { code: -32603, message: 'Internal error' }, id: null }));
+      } else {
+        res.end();
+      }
+      cleanup();
+    }
+  });
+
+  const listening = await listen(httpServer, options.port);
+  if (!listening) {
+    return null;
+  }
+
+  return {
+    actualPort: listening.port,
+    address: listening.address,
+    close: async () => {
+      await new Promise<void>((resolve) => {
+        httpServer.close(() => resolve());
+      });
+    },
+  };
+}

--- a/src/main/mcp/status.test.ts
+++ b/src/main/mcp/status.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createMcpStatusEmitter } from './status';
+
+describe('createMcpStatusEmitter', () => {
+  it('starts with running=false and port=null', () => {
+    const emitter = createMcpStatusEmitter();
+    expect(emitter.get()).toEqual({ running: false, port: null });
+  });
+
+  it('set() updates the current value', () => {
+    const emitter = createMcpStatusEmitter();
+    emitter.set({ running: true, port: 27099 });
+    expect(emitter.get()).toEqual({ running: true, port: 27099 });
+  });
+
+  it('subscribe() invokes callback on subsequent set() calls', () => {
+    const emitter = createMcpStatusEmitter();
+    const cb = vi.fn();
+    emitter.subscribe(cb);
+    emitter.set({ running: true, port: 27099 });
+    emitter.set({ running: false, port: null });
+    expect(cb).toHaveBeenNthCalledWith(1, { running: true, port: 27099 });
+    expect(cb).toHaveBeenNthCalledWith(2, { running: false, port: null });
+  });
+
+  it('subscribe() does not fire for a set() that produces an equal status', () => {
+    const emitter = createMcpStatusEmitter();
+    const cb = vi.fn();
+    emitter.subscribe(cb);
+    emitter.set({ running: false, port: null });
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it('subscribe() returns an unsubscribe function', () => {
+    const emitter = createMcpStatusEmitter();
+    const cb = vi.fn();
+    const unsubscribe = emitter.subscribe(cb);
+    emitter.set({ running: true, port: 27099 });
+    unsubscribe();
+    emitter.set({ running: false, port: null });
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('supports multiple independent subscribers', () => {
+    const emitter = createMcpStatusEmitter();
+    const a = vi.fn();
+    const b = vi.fn();
+    emitter.subscribe(a);
+    emitter.subscribe(b);
+    emitter.set({ running: true, port: 1234 });
+    expect(a).toHaveBeenCalledWith({ running: true, port: 1234 });
+    expect(b).toHaveBeenCalledWith({ running: true, port: 1234 });
+  });
+});

--- a/src/main/mcp/status.ts
+++ b/src/main/mcp/status.ts
@@ -1,0 +1,33 @@
+import type { McpStatus } from '../../shared/types';
+
+export interface McpStatusEmitter {
+  get: () => McpStatus;
+  set: (next: McpStatus) => void;
+  subscribe: (cb: (s: McpStatus) => void) => () => void;
+}
+
+const INITIAL: McpStatus = { running: false, port: null };
+
+function equals(a: McpStatus, b: McpStatus): boolean {
+  return a.running === b.running && a.port === b.port;
+}
+
+export function createMcpStatusEmitter(): McpStatusEmitter {
+  let current: McpStatus = INITIAL;
+  const subscribers = new Set<(s: McpStatus) => void>();
+
+  return {
+    get: () => current,
+    set: (next: McpStatus) => {
+      if (equals(current, next)) return;
+      current = next;
+      for (const cb of subscribers) cb(current);
+    },
+    subscribe: (cb) => {
+      subscribers.add(cb);
+      return () => {
+        subscribers.delete(cb);
+      };
+    },
+  };
+}

--- a/src/main/mcp/tools.test.ts
+++ b/src/main/mcp/tools.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { registerMcpTools } from './tools';
+import type { MongoService } from '../mongo-service';
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  content: { type: 'text'; text: string }[];
+  isError?: boolean;
+}>;
+
+interface ServerInternals {
+  _registeredTools: Record<string, { handler: ToolHandler }>;
+}
+
+function createServer(): McpServer {
+  return new McpServer({ name: 'mongo-buddy', version: 'test' }, { capabilities: { tools: {} } });
+}
+
+function registered(server: McpServer): Record<string, { handler: ToolHandler }> {
+  return (server as unknown as ServerInternals)._registeredTools;
+}
+
+function getHandler(server: McpServer, name: string): ToolHandler {
+  const tools = registered(server);
+  const tool = tools[name];
+  if (!tool) throw new Error(`Tool ${name} not registered`);
+  return tool.handler;
+}
+
+function createServiceMock(): {
+  service: MongoService;
+  mocks: {
+    listDatabases: ReturnType<typeof vi.fn>;
+    listCollections: ReturnType<typeof vi.fn>;
+    sampleFields: ReturnType<typeof vi.fn>;
+    find: ReturnType<typeof vi.fn>;
+    count: ReturnType<typeof vi.fn>;
+    aggregate: ReturnType<typeof vi.fn>;
+    distinct: ReturnType<typeof vi.fn>;
+  };
+} {
+  const mocks = {
+    listDatabases: vi.fn(),
+    listCollections: vi.fn(),
+    sampleFields: vi.fn(),
+    find: vi.fn(),
+    count: vi.fn(),
+    aggregate: vi.fn(),
+    distinct: vi.fn(),
+  };
+  return { service: mocks as unknown as MongoService, mocks };
+}
+
+describe('registerMcpTools', () => {
+  let server: McpServer;
+  let service: MongoService;
+  let mocks: ReturnType<typeof createServiceMock>['mocks'];
+
+  beforeEach(() => {
+    server = createServer();
+    const built = createServiceMock();
+    service = built.service;
+    mocks = built.mocks;
+    registerMcpTools(server, service);
+  });
+
+  it('registers exactly 7 tools', () => {
+    const names = Object.keys(registered(server)).sort();
+    expect(names).toEqual(
+      ['aggregate', 'count', 'distinct', 'find', 'list_collections', 'list_databases', 'sample_fields'].sort()
+    );
+  });
+
+  describe('list_databases', () => {
+    it('returns serialized data on success', async () => {
+      const data = [{ name: 'db1', sizeOnDisk: 10, empty: false }];
+      mocks.listDatabases.mockResolvedValue({ ok: true, data });
+      const result = await getHandler(server, 'list_databases')({});
+      expect(result.isError).toBeUndefined();
+      expect(JSON.parse(result.content[0].text)).toEqual(data);
+    });
+
+    it('returns isError on failure', async () => {
+      mocks.listDatabases.mockResolvedValue({ ok: false, error: 'boom' });
+      const result = await getHandler(server, 'list_databases')({});
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe('boom');
+    });
+
+    it('rewrites "Not connected" error', async () => {
+      mocks.listDatabases.mockResolvedValue({ ok: false, error: 'Not connected' });
+      const result = await getHandler(server, 'list_databases')({});
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe('Not connected. Connect via the mongo-buddy GUI first.');
+    });
+  });
+
+  describe('list_collections', () => {
+    it('calls service with db arg and returns data', async () => {
+      const data = [{ name: 'c1', type: 'collection' }];
+      mocks.listCollections.mockResolvedValue({ ok: true, data });
+      const result = await getHandler(server, 'list_collections')({ db: 'mydb' });
+      expect(mocks.listCollections).toHaveBeenCalledWith('mydb');
+      expect(JSON.parse(result.content[0].text)).toEqual(data);
+    });
+
+    it('rewrites disconnect error', async () => {
+      mocks.listCollections.mockResolvedValue({ ok: false, error: 'Not connected' });
+      const result = await getHandler(server, 'list_collections')({ db: 'mydb' });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe('Not connected. Connect via the mongo-buddy GUI first.');
+    });
+  });
+
+  describe('sample_fields', () => {
+    it('calls service with db and collection', async () => {
+      mocks.sampleFields.mockResolvedValue({ ok: true, data: ['_id', 'name'] });
+      const result = await getHandler(server, 'sample_fields')({ db: 'd', collection: 'c' });
+      expect(mocks.sampleFields).toHaveBeenCalledWith('d', 'c');
+      expect(JSON.parse(result.content[0].text)).toEqual(['_id', 'name']);
+    });
+  });
+
+  describe('find', () => {
+    it('uses default limit of 50 when not provided', async () => {
+      mocks.find.mockResolvedValue({ ok: true, data: { docs: [], totalCount: 0 } });
+      await getHandler(server, 'find')({ db: 'd', collection: 'c' });
+      const call = mocks.find.mock.calls[0];
+      expect(call[2].limit).toBe(50);
+    });
+
+    it('clamps limit above 200 to 200', async () => {
+      mocks.find.mockResolvedValue({ ok: true, data: { docs: [], totalCount: 0 } });
+      await getHandler(server, 'find')({ db: 'd', collection: 'c', limit: 999 });
+      expect(mocks.find.mock.calls[0][2].limit).toBe(200);
+    });
+
+    it('respects a limit within range', async () => {
+      mocks.find.mockResolvedValue({ ok: true, data: { docs: [], totalCount: 0 } });
+      await getHandler(server, 'find')({ db: 'd', collection: 'c', limit: 10 });
+      expect(mocks.find.mock.calls[0][2].limit).toBe(10);
+    });
+
+    it('passes filter, sort, skip through', async () => {
+      mocks.find.mockResolvedValue({ ok: true, data: { docs: [], totalCount: 0 } });
+      const filter = { _id: { $oid: '507f1f77bcf86cd799439011' } };
+      const sort = { name: 1 as const };
+      await getHandler(server, 'find')({ db: 'd', collection: 'c', filter, sort, skip: 5 });
+      const opts = mocks.find.mock.calls[0][2];
+      expect(opts.filter).toEqual(filter);
+      expect(opts.sort).toEqual(sort);
+      expect(opts.skip).toBe(5);
+    });
+
+    it('response includes totalCount so LLM can paginate', async () => {
+      mocks.find.mockResolvedValue({ ok: true, data: { docs: [{ a: 1 }], totalCount: 42 } });
+      const result = await getHandler(server, 'find')({ db: 'd', collection: 'c' });
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.totalCount).toBe(42);
+      expect(parsed.docs).toEqual([{ a: 1 }]);
+    });
+
+    it('rewrites disconnect error', async () => {
+      mocks.find.mockResolvedValue({ ok: false, error: 'Not connected' });
+      const result = await getHandler(server, 'find')({ db: 'd', collection: 'c' });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe('Not connected. Connect via the mongo-buddy GUI first.');
+    });
+  });
+
+  describe('count', () => {
+    it('passes filter through and returns count', async () => {
+      mocks.count.mockResolvedValue({ ok: true, data: 12 });
+      const filter = { active: true };
+      const result = await getHandler(server, 'count')({ db: 'd', collection: 'c', filter });
+      expect(mocks.count).toHaveBeenCalledWith('d', 'c', filter);
+      expect(JSON.parse(result.content[0].text)).toBe(12);
+    });
+
+    it('defaults filter to {} when omitted', async () => {
+      mocks.count.mockResolvedValue({ ok: true, data: 0 });
+      await getHandler(server, 'count')({ db: 'd', collection: 'c' });
+      expect(mocks.count).toHaveBeenCalledWith('d', 'c', {});
+    });
+  });
+
+  describe('aggregate', () => {
+    it('passes pipeline through', async () => {
+      mocks.aggregate.mockResolvedValue({ ok: true, data: [{ _id: 'x', count: 2 }] });
+      const pipeline = [{ $match: { x: 1 } }, { $group: { _id: '$x', count: { $sum: 1 } } }];
+      const result = await getHandler(server, 'aggregate')({ db: 'd', collection: 'c', pipeline });
+      expect(mocks.aggregate).toHaveBeenCalledWith('d', 'c', pipeline);
+      expect(JSON.parse(result.content[0].text)).toEqual([{ _id: 'x', count: 2 }]);
+    });
+  });
+
+  describe('distinct', () => {
+    it('passes field and filter through', async () => {
+      mocks.distinct.mockResolvedValue({ ok: true, data: { values: ['a', 'b'], truncated: false } });
+      const result = await getHandler(
+        server,
+        'distinct'
+      )({
+        db: 'd',
+        collection: 'c',
+        field: 'status',
+        filter: { active: true },
+      });
+      expect(mocks.distinct).toHaveBeenCalledWith('d', 'c', 'status', { active: true });
+      expect(JSON.parse(result.content[0].text)).toEqual({ values: ['a', 'b'], truncated: false });
+    });
+
+    it('defaults filter to {}', async () => {
+      mocks.distinct.mockResolvedValue({ ok: true, data: { values: [], truncated: false } });
+      await getHandler(server, 'distinct')({ db: 'd', collection: 'c', field: 'status' });
+      expect(mocks.distinct).toHaveBeenCalledWith('d', 'c', 'status', {});
+    });
+  });
+});

--- a/src/main/mcp/tools.ts
+++ b/src/main/mcp/tools.ts
@@ -1,0 +1,145 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import type { MongoService } from '../mongo-service';
+import type { Result } from '../../shared/types';
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+const DISCONNECT_MESSAGE = 'Not connected. Connect via the mongo-buddy GUI first.';
+
+const EJSON_HINT =
+  'Filters and pipelines must be MongoDB Extended JSON (EJSON). Use {"$oid": "..."} for ObjectId, {"$date": "..."} for Date, {"$numberLong": "..."} for Long, etc.';
+
+function toToolResult<T>(result: Result<T>): CallToolResult {
+  if (result.ok) {
+    return { content: [{ type: 'text', text: JSON.stringify(result.data) }] };
+  }
+  const message = result.error === 'Not connected' ? DISCONNECT_MESSAGE : result.error;
+  return { isError: true, content: [{ type: 'text', text: message }] };
+}
+
+function clampLimit(value: number | undefined): number {
+  if (value === undefined) return DEFAULT_LIMIT;
+  if (value > MAX_LIMIT) return MAX_LIMIT;
+  return value;
+}
+
+export function registerMcpTools(server: McpServer, service: MongoService): void {
+  server.registerTool(
+    'list_databases',
+    {
+      description:
+        'List all databases on the currently connected MongoDB server with name, size on disk, and empty flag.',
+      inputSchema: {},
+    },
+    async () => toToolResult(await service.listDatabases())
+  );
+
+  server.registerTool(
+    'list_collections',
+    {
+      description: 'List all collections in the given database, including type and estimated document count.',
+      inputSchema: {
+        db: z.string().describe('Database name'),
+      },
+    },
+    async ({ db }) => toToolResult(await service.listCollections(db))
+  );
+
+  server.registerTool(
+    'sample_fields',
+    {
+      description:
+        'Sample up to 50 documents from a collection and return the union of top-level field names. Use this to discover the shape of a collection before writing a query.',
+      inputSchema: {
+        db: z.string().describe('Database name'),
+        collection: z.string().describe('Collection name'),
+      },
+    },
+    async ({ db, collection }) => toToolResult(await service.sampleFields(db, collection))
+  );
+
+  server.registerTool(
+    'find',
+    {
+      description: `Find documents in a collection. Returns { docs, totalCount } where totalCount ignores skip/limit — use it to paginate via skip. Default limit is ${DEFAULT_LIMIT}, max is ${MAX_LIMIT} (values above are clamped). ${EJSON_HINT}`,
+      inputSchema: {
+        db: z.string().describe('Database name'),
+        collection: z.string().describe('Collection name'),
+        filter: z
+          .record(z.string(), z.unknown())
+          .optional()
+          .describe(
+            'MongoDB query filter in EJSON (e.g. {"status": "active"} or {"_id": {"$oid": "507f1f77bcf86cd799439011"}})'
+          ),
+        sort: z
+          .record(z.string(), z.union([z.literal(1), z.literal(-1)]))
+          .optional()
+          .describe('Sort spec, e.g. {"createdAt": -1}'),
+        skip: z.number().int().min(0).optional().describe('Number of documents to skip (for pagination)'),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .optional()
+          .describe(`Max documents to return (default ${DEFAULT_LIMIT}, clamped to ${MAX_LIMIT})`),
+      },
+    },
+    async ({ db, collection, filter, sort, skip, limit }) => {
+      const opts = {
+        filter,
+        sort,
+        skip,
+        limit: clampLimit(limit),
+      };
+      return toToolResult(await service.find(db, collection, opts));
+    }
+  );
+
+  server.registerTool(
+    'count',
+    {
+      description: `Count documents matching a filter. ${EJSON_HINT}`,
+      inputSchema: {
+        db: z.string().describe('Database name'),
+        collection: z.string().describe('Collection name'),
+        filter: z
+          .record(z.string(), z.unknown())
+          .optional()
+          .describe('MongoDB query filter in EJSON. Defaults to {} (count all).'),
+      },
+    },
+    async ({ db, collection, filter }) => toToolResult(await service.count(db, collection, filter ?? {}))
+  );
+
+  server.registerTool(
+    'aggregate',
+    {
+      description: `Run an aggregation pipeline against a collection. Returns the resulting documents. ${EJSON_HINT}`,
+      inputSchema: {
+        db: z.string().describe('Database name'),
+        collection: z.string().describe('Collection name'),
+        pipeline: z
+          .array(z.record(z.string(), z.unknown()))
+          .describe('Aggregation pipeline in EJSON, e.g. [{"$match": {...}}, {"$group": {...}}]'),
+      },
+    },
+    async ({ db, collection, pipeline }) => toToolResult(await service.aggregate(db, collection, pipeline))
+  );
+
+  server.registerTool(
+    'distinct',
+    {
+      description: `Return the distinct values of a field in a collection. Response includes a "truncated" flag if the result was clipped. ${EJSON_HINT}`,
+      inputSchema: {
+        db: z.string().describe('Database name'),
+        collection: z.string().describe('Collection name'),
+        field: z.string().describe('Field name to get distinct values for (supports dot notation)'),
+        filter: z.record(z.string(), z.unknown()).optional().describe('Optional EJSON filter. Defaults to {}.'),
+      },
+    },
+    async ({ db, collection, field, filter }) =>
+      toToolResult(await service.distinct(db, collection, field, filter ?? {}))
+  );
+}

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -16,6 +16,7 @@ import type {
   OperationResult,
   OperationRecord,
   OperationProgress,
+  McpStatus,
 } from '../shared/types';
 import type { ConnectionState, ConnectedSession, ConnectOptions } from '../main/connection-manager';
 
@@ -72,6 +73,8 @@ interface MongoApi {
   operationStart(params: OperationParams): Promise<Result<OperationId>>;
   operationCancel(id: OperationId): Promise<Result<undefined>>;
   onOperationUpdate(cb: (rec: OperationRecord) => void): () => void;
+  getMcpStatus(): Promise<McpStatus>;
+  onMcpStatusUpdate(cb: (status: McpStatus) => void): () => void;
 }
 
 declare global {

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -11,6 +11,7 @@ vi.mock('@electron-toolkit/preload', () => ({
 
 import { createApi } from './index';
 import type { ConnectionState, ConnectedSession } from '../main/connection-manager';
+import type { McpStatus } from '../shared/types';
 
 describe('preload createApi', () => {
   let invoke: ReturnType<typeof vi.fn>;
@@ -107,6 +108,49 @@ describe('preload createApi', () => {
 
       expect(off).toHaveBeenNthCalledWith(1, 'connection:state', handler1);
       expect(off).toHaveBeenNthCalledWith(2, 'connection:state', handler2);
+    });
+  });
+
+  describe('getMcpStatus', () => {
+    it('invokes mcp:status:get and returns the McpStatus payload', async () => {
+      const status: McpStatus = { running: true, port: 27099 };
+      invoke.mockResolvedValue(status);
+      const api = createApi(ipcRenderer);
+
+      const result = await api.getMcpStatus();
+
+      expect(invoke).toHaveBeenCalledWith('mcp:status:get');
+      expect(result).toEqual(status);
+    });
+  });
+
+  describe('onMcpStatusUpdate', () => {
+    it('registers a listener on mcp:status:update and forwards the payload', () => {
+      const api = createApi(ipcRenderer);
+      const cb = vi.fn();
+
+      api.onMcpStatusUpdate(cb);
+
+      expect(on).toHaveBeenCalledTimes(1);
+      const [channel, handler] = on.mock.calls[0];
+      expect(channel).toBe('mcp:status:update');
+
+      const status: McpStatus = { running: true, port: 27099 };
+      (handler as (event: unknown, data: McpStatus) => void)({}, status);
+
+      expect(cb).toHaveBeenCalledWith(status);
+    });
+
+    it('returns an unsubscribe function that removes the exact listener via ipcRenderer.off', () => {
+      const api = createApi(ipcRenderer);
+      const cb = vi.fn();
+
+      const unsubscribe = api.onMcpStatusUpdate(cb);
+      const registeredHandler = on.mock.calls[0][1];
+
+      unsubscribe();
+
+      expect(off).toHaveBeenCalledWith('mcp:status:update', registeredHandler);
     });
   });
 });

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -13,6 +13,7 @@ import type {
   OperationParams,
   OperationId,
   OperationRecord,
+  McpStatus,
 } from '../shared/types';
 import type { ConnectionState, ConnectedSession, ConnectOptions } from '../main/connection-manager';
 
@@ -91,6 +92,12 @@ export function createApi(ipc: IpcLike) {
       const handler = (_event: unknown, rec: OperationRecord): void => cb(rec);
       ipc.on('operation:update', handler as (event: unknown, ...args: unknown[]) => void);
       return () => ipc.off('operation:update', handler as (event: unknown, ...args: unknown[]) => void);
+    },
+    getMcpStatus: (): Promise<McpStatus> => ipc.invoke('mcp:status:get') as Promise<McpStatus>,
+    onMcpStatusUpdate: (cb: (s: McpStatus) => void): (() => void) => {
+      const handler = (_event: unknown, s: McpStatus): void => cb(s);
+      ipc.on('mcp:status:update', handler as (event: unknown, ...args: unknown[]) => void);
+      return () => ipc.off('mcp:status:update', handler as (event: unknown, ...args: unknown[]) => void);
     },
   };
 }

--- a/src/renderer/src/components/McpStatusPill.tsx
+++ b/src/renderer/src/components/McpStatusPill.tsx
@@ -1,0 +1,16 @@
+import { useStore } from '../store';
+
+export function McpStatusPill() {
+  const mcpStatus = useStore((s) => s.mcpStatus);
+
+  if (!mcpStatus.running) return null;
+
+  return (
+    <span
+      className="text-[10px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded-full"
+      title={`MCP server listening on port ${mcpStatus.port}`}
+    >
+      MCP: on (port {mcpStatus.port})
+    </span>
+  );
+}

--- a/src/renderer/src/components/Sidebar.tsx
+++ b/src/renderer/src/components/Sidebar.tsx
@@ -8,6 +8,7 @@ import { Unplug, Download, EllipsisVertical, Upload, X, Trash2, RefreshCw } from
 import { Menu } from '@base-ui/react/menu';
 import { toast } from 'sonner';
 import { ImportDialog } from './ImportDialog';
+import { McpStatusPill } from './McpStatusPill';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from './ui/dialog';
 import { Input } from './ui/input';
 import { getConnectionDisplayName } from '../lib/connection-name';
@@ -514,19 +515,22 @@ export function Sidebar({ width, onResize, onChangeConnection }: SidebarProps) {
 
   return (
     <div className="border-r bg-muted/30 flex flex-col relative" style={{ width }}>
-      <div className="p-3 font-semibold text-sm border-b flex items-center justify-between">
+      <div className="p-3 font-semibold text-sm border-b flex items-center justify-between gap-2">
         <span className="truncate" title={displayName}>
           {displayName}
         </span>
-        {onChangeConnection && (
-          <button
-            className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground"
-            onClick={onChangeConnection}
-            title="Change connection"
-          >
-            <Unplug className="h-3.5 w-3.5" />
-          </button>
-        )}
+        <div className="flex items-center gap-1 shrink-0">
+          <McpStatusPill />
+          {onChangeConnection && (
+            <button
+              className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground"
+              onClick={onChangeConnection}
+              title="Change connection"
+            >
+              <Unplug className="h-3.5 w-3.5" />
+            </button>
+          )}
+        </div>
       </div>
       <ScrollArea className="flex-1">
         <div className="p-2 space-y-1">

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -6,6 +6,7 @@ import { subscribeOperationStream } from './hooks/use-operation';
 import './assets/index.css';
 
 useStore.getState().subscribeToConnectionState();
+useStore.getState().initMcpStatus();
 subscribeOperationStream();
 
 ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/src/renderer/src/store.test.ts
+++ b/src/renderer/src/store.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { useStore, selectConnected } from './store';
-import type { ConnectionState, ConnectedSession } from '../../shared/types';
+import type { ConnectionState, ConnectedSession, McpStatus } from '../../shared/types';
 
 const mockApi = {
   connect: vi.fn(),
@@ -24,6 +24,8 @@ const mockApi = {
   saveHistory: vi.fn().mockResolvedValue(undefined),
   clearHistory: vi.fn().mockResolvedValue(undefined),
   distinct: vi.fn(),
+  getMcpStatus: vi.fn<() => Promise<McpStatus>>().mockResolvedValue({ running: false, port: null }),
+  onMcpStatusUpdate: vi.fn<(cb: (s: McpStatus) => void) => () => void>(() => () => {}),
 };
 
 function makeSession(overrides: Partial<ConnectedSession> = {}): ConnectedSession {
@@ -41,6 +43,8 @@ function makeSession(overrides: Partial<ConnectedSession> = {}): ConnectedSessio
 beforeEach(() => {
   vi.clearAllMocks();
   mockApi.onConnectionState.mockImplementation(() => () => {});
+  mockApi.onMcpStatusUpdate.mockImplementation(() => () => {});
+  mockApi.getMcpStatus.mockResolvedValue({ running: false, port: null });
   useStore.setState({
     status: { status: 'disconnected' } as ConnectionState,
     uri: '',
@@ -61,6 +65,7 @@ beforeEach(() => {
     pendingFilterText: null,
     queryHistory: [],
     pendingQueryMode: null,
+    mcpStatus: { running: false, port: null },
   });
   (window as unknown as Record<string, unknown>).api = mockApi;
 });
@@ -643,6 +648,42 @@ describe('subscribeToConnectionState', () => {
     mockApi.onConnectionState.mockImplementation(() => unsubSpy);
 
     const unsub = useStore.getState().subscribeToConnectionState();
+    unsub();
+
+    expect(unsubSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('initMcpStatus', () => {
+  it('subscribes to updates and hydrates from getMcpStatus', async () => {
+    let emit: (s: McpStatus) => void = () => {};
+    mockApi.onMcpStatusUpdate.mockImplementation((cb: (s: McpStatus) => void) => {
+      emit = cb;
+      return () => {};
+    });
+    mockApi.getMcpStatus.mockResolvedValue({ running: true, port: 27099 });
+
+    useStore.getState().initMcpStatus();
+
+    expect(mockApi.onMcpStatusUpdate).toHaveBeenCalledTimes(1);
+    expect(mockApi.getMcpStatus).toHaveBeenCalledTimes(1);
+
+    await vi.waitFor(() => {
+      expect(useStore.getState().mcpStatus).toEqual({ running: true, port: 27099 });
+    });
+
+    emit({ running: false, port: null });
+    expect(useStore.getState().mcpStatus).toEqual({ running: false, port: null });
+
+    emit({ running: true, port: 9999 });
+    expect(useStore.getState().mcpStatus).toEqual({ running: true, port: 9999 });
+  });
+
+  it('returns the unsubscribe function from onMcpStatusUpdate', () => {
+    const unsubSpy = vi.fn();
+    mockApi.onMcpStatusUpdate.mockImplementation(() => unsubSpy);
+
+    const unsub = useStore.getState().initMcpStatus();
     unsub();
 
     expect(unsubSpy).toHaveBeenCalledTimes(1);

--- a/src/renderer/src/store.ts
+++ b/src/renderer/src/store.ts
@@ -8,6 +8,7 @@ import type {
   DistinctResult,
   Result,
   ConnectionState,
+  McpStatus,
 } from '../../shared/types';
 
 export interface StoreState {
@@ -31,10 +32,12 @@ export interface StoreState {
   pendingFilterText: string | null;
   queryHistory: QueryHistoryEntry[];
   pendingQueryMode: 'filter' | 'aggregate' | null;
+  mcpStatus: McpStatus;
 
   connect: (uri: string) => Promise<void>;
   disconnect: () => Promise<void>;
   subscribeToConnectionState: () => () => void;
+  initMcpStatus: () => () => void;
   selectDb: (db: string) => Promise<void>;
   selectCollection: (db: string, collection: string) => Promise<void>;
   fetchPage: (skip: number) => Promise<void>;
@@ -81,6 +84,7 @@ export const useStore = create<StoreState>()((set, get) => ({
   pendingFilterText: null,
   queryHistory: [],
   pendingQueryMode: null,
+  mcpStatus: { running: false, port: null },
 
   connect: async (uri: string) => {
     if (selectConnected(get())) await get().disconnect();
@@ -112,6 +116,12 @@ export const useStore = create<StoreState>()((set, get) => ({
   },
 
   subscribeToConnectionState: () => window.api.onConnectionState((status) => set({ status })),
+
+  initMcpStatus: () => {
+    const unsubscribe = window.api.onMcpStatusUpdate((mcpStatus) => set({ mcpStatus }));
+    window.api.getMcpStatus().then((mcpStatus) => set({ mcpStatus }));
+    return unsubscribe;
+  },
 
   selectDb: async (db: string) => {
     set({ loading: true, selectedDb: db, selectedCollection: null, docs: [], totalCount: 0, fieldNames: [] });

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -131,3 +131,8 @@ export interface OperationRecord {
   result?: OperationResult;
   error?: string;
 }
+
+export interface McpStatus {
+  running: boolean;
+  port: number | null;
+}


### PR DESCRIPTION
### What does this PR do?


Let an external LLM (Claude Desktop, Cursor, etc.) query the MongoDB the user is currently connected to in the GUI. An MCP server runs inside the Electron main process; LLM connects over HTTP to `127.0.0.1`. Read-only, unauthenticated, localhost-bound, opt-in via CLI flag `--mcp`.

### Changes

- [x] #32 MCP: add deps + CLI args parser
- [x] #33 MCP: implement read-only tools wrapping MongoService
- [x] #34 MCP: HTTP server bootstrap (Streamable HTTP, localhost)
- [x] #35 MCP: wire into Electron main lifecycle
- [x] #36 MCP: status emitter + IPC + preload API
- [x] #37 MCP: renderer status pill + Sidebar integration

### Related issues

Closes #31

### Additional notes

Generated by Ralph (resumed).