### PR TITLE
List collection indexes (read-only) in GUI and via MCP

### DIFF
--- a/src/main/ipc-handlers.test.ts
+++ b/src/main/ipc-handlers.test.ts
@@ -38,6 +38,7 @@ describe('IPC Handlers', () => {
     updateOne: ReturnType<typeof vi.fn>;
     deleteOne: ReturnType<typeof vi.fn>;
     distinct: ReturnType<typeof vi.fn>;
+    listIndexes: ReturnType<typeof vi.fn>;
   };
   let mockConnStore: {
     getAll: ReturnType<typeof vi.fn>;
@@ -103,6 +104,7 @@ describe('IPC Handlers', () => {
       updateOne: vi.fn(),
       deleteOne: vi.fn(),
       distinct: vi.fn(),
+      listIndexes: vi.fn(),
     };
 
     mockConnStore = {
@@ -168,6 +170,7 @@ describe('IPC Handlers', () => {
     expect(handlers['mongo:disconnect']).toBeDefined();
     expect(handlers['mongo:list-databases']).toBeDefined();
     expect(handlers['mongo:list-collections']).toBeDefined();
+    expect(handlers['mongo:list-indexes']).toBeDefined();
     expect(handlers['mongo:find']).toBeDefined();
     expect(handlers['mongo:count']).toBeDefined();
     expect(handlers['mongo:aggregate']).toBeDefined();
@@ -259,6 +262,22 @@ describe('IPC Handlers', () => {
       const result = await handlers['mongo:list-collections']({} as Electron.IpcMainInvokeEvent, 'testdb');
       expect(mockService.listCollections).toHaveBeenCalledWith('testdb');
       expect(result).toEqual({ ok: true, data: colls });
+    });
+  });
+
+  describe('mongo:list-indexes', () => {
+    it('calls MongoService.listIndexes with db and collection', async () => {
+      const indexes = [{ v: 2, key: { _id: 1 }, name: '_id_' }];
+      mockService.listIndexes.mockResolvedValue({ ok: true, data: indexes });
+      const result = await handlers['mongo:list-indexes']({} as Electron.IpcMainInvokeEvent, 'testdb', 'users');
+      expect(mockService.listIndexes).toHaveBeenCalledWith('testdb', 'users');
+      expect(result).toEqual({ ok: true, data: indexes });
+    });
+
+    it('forwards service error result', async () => {
+      mockService.listIndexes.mockResolvedValue({ ok: false, error: 'ns not found' });
+      const result = await handlers['mongo:list-indexes']({} as Electron.IpcMainInvokeEvent, 'testdb', 'users');
+      expect(result).toEqual({ ok: false, error: 'ns not found' });
     });
   });
 

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -84,6 +84,10 @@ export function registerIpcHandlers(deps: IpcDeps): void {
     wrap((db: unknown) => service.listCollections(db as string))
   );
   ipcMain.handle(
+    'mongo:list-indexes',
+    wrap((db: unknown, coll: unknown) => service.listIndexes(db as string, coll as string))
+  );
+  ipcMain.handle(
     'mongo:find',
     wrap((db: unknown, coll: unknown, opts: unknown) => service.find(db as string, coll as string, opts as FindOpts))
   );

--- a/src/main/mcp/server.test.ts
+++ b/src/main/mcp/server.test.ts
@@ -12,6 +12,7 @@ const EXPECTED_TOOL_NAMES = [
   'find',
   'list_collections',
   'list_databases',
+  'list_indexes',
   'sample_fields',
 ].sort();
 

--- a/src/main/mcp/tools.test.ts
+++ b/src/main/mcp/tools.test.ts
@@ -37,6 +37,7 @@ function createServiceMock(): {
     count: ReturnType<typeof vi.fn>;
     aggregate: ReturnType<typeof vi.fn>;
     distinct: ReturnType<typeof vi.fn>;
+    listIndexes: ReturnType<typeof vi.fn>;
   };
 } {
   const mocks = {
@@ -47,6 +48,7 @@ function createServiceMock(): {
     count: vi.fn(),
     aggregate: vi.fn(),
     distinct: vi.fn(),
+    listIndexes: vi.fn(),
   };
   return { service: mocks as unknown as MongoService, mocks };
 }
@@ -64,10 +66,19 @@ describe('registerMcpTools', () => {
     registerMcpTools(server, service);
   });
 
-  it('registers exactly 7 tools', () => {
+  it('registers exactly 8 tools', () => {
     const names = Object.keys(registered(server)).sort();
     expect(names).toEqual(
-      ['aggregate', 'count', 'distinct', 'find', 'list_collections', 'list_databases', 'sample_fields'].sort()
+      [
+        'aggregate',
+        'count',
+        'distinct',
+        'find',
+        'list_collections',
+        'list_databases',
+        'list_indexes',
+        'sample_fields',
+      ].sort()
     );
   });
 
@@ -191,6 +202,34 @@ describe('registerMcpTools', () => {
       const result = await getHandler(server, 'aggregate')({ db: 'd', collection: 'c', pipeline });
       expect(mocks.aggregate).toHaveBeenCalledWith('d', 'c', pipeline);
       expect(JSON.parse(result.content[0].text)).toEqual([{ _id: 'x', count: 2 }]);
+    });
+  });
+
+  describe('list_indexes', () => {
+    it('calls service with db and collection and returns serialized data', async () => {
+      const data = [
+        { v: 2, key: { _id: 1 }, name: '_id_' },
+        { v: 2, key: { email: 1 }, name: 'email_1', unique: true },
+      ];
+      mocks.listIndexes.mockResolvedValue({ ok: true, data });
+      const result = await getHandler(server, 'list_indexes')({ db: 'd', collection: 'c' });
+      expect(mocks.listIndexes).toHaveBeenCalledWith('d', 'c');
+      expect(result.isError).toBeUndefined();
+      expect(JSON.parse(result.content[0].text)).toEqual(data);
+    });
+
+    it('returns isError on failure', async () => {
+      mocks.listIndexes.mockResolvedValue({ ok: false, error: 'ns not found' });
+      const result = await getHandler(server, 'list_indexes')({ db: 'd', collection: 'c' });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe('ns not found');
+    });
+
+    it('rewrites "Not connected" error', async () => {
+      mocks.listIndexes.mockResolvedValue({ ok: false, error: 'Not connected' });
+      const result = await getHandler(server, 'list_indexes')({ db: 'd', collection: 'c' });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe('Not connected. Connect via the mongo-buddy GUI first.');
     });
   });
 

--- a/src/main/mcp/tools.ts
+++ b/src/main/mcp/tools.ts
@@ -129,6 +129,18 @@ export function registerMcpTools(server: McpServer, service: MongoService): void
   );
 
   server.registerTool(
+    'list_indexes',
+    {
+      description: 'List all indexes on a collection (raw spec from MongoDB)',
+      inputSchema: {
+        db: z.string().describe('Database name'),
+        collection: z.string().describe('Collection name'),
+      },
+    },
+    async ({ db, collection }) => toToolResult(await service.listIndexes(db, collection))
+  );
+
+  server.registerTool(
     'distinct',
     {
       description: `Return the distinct values of a field in a collection. Response includes a "truncated" flag if the result was clipped. ${EJSON_HINT}`,

--- a/src/main/mongo-service.test.ts
+++ b/src/main/mongo-service.test.ts
@@ -28,6 +28,7 @@ describe('MongoService', () => {
     replaceOne: ReturnType<typeof vi.fn>;
     deleteOne: ReturnType<typeof vi.fn>;
     distinct: ReturnType<typeof vi.fn>;
+    indexes: ReturnType<typeof vi.fn>;
   };
   let requireClient: ReturnType<typeof vi.fn<() => MongoClient>>;
 
@@ -44,6 +45,7 @@ describe('MongoService', () => {
       replaceOne: vi.fn(),
       deleteOne: vi.fn(),
       distinct: vi.fn(),
+      indexes: vi.fn(),
     };
     mockDb = {
       listCollections: vi.fn().mockReturnValue({ toArray: vi.fn().mockResolvedValue([]) }),
@@ -688,6 +690,82 @@ describe('MongoService', () => {
         new AbortController().signal
       );
       expect(result).toEqual({ ok: false, error: 'Not connected' });
+    });
+  });
+
+  describe('listIndexes', () => {
+    it('returns EJSON-serialized index documents', async () => {
+      const indexes = [
+        { v: 2, key: { _id: 1 }, name: '_id_' },
+        { v: 2, key: { email: 1 }, name: 'email_1', unique: true },
+      ];
+      mockCollection.indexes.mockResolvedValue(indexes);
+
+      const result = await service.listIndexes('testdb', 'users');
+
+      expect(mockClient.db).toHaveBeenCalledWith('testdb');
+      expect(mockDb.collection).toHaveBeenCalledWith('users');
+      expect(mockCollection.indexes).toHaveBeenCalled();
+      expect(result).toEqual({
+        ok: true,
+        data: [
+          { v: 2, key: { _id: 1 }, name: '_id_' },
+          { v: 2, key: { email: 1 }, name: 'email_1', unique: true },
+        ],
+      });
+    });
+
+    it('preserves additional fields like partialFilterExpression and expireAfterSeconds', async () => {
+      const indexes = [
+        {
+          v: 2,
+          key: { createdAt: 1 },
+          name: 'ttl_idx',
+          expireAfterSeconds: 3600,
+          partialFilterExpression: { archived: false },
+        },
+      ];
+      mockCollection.indexes.mockResolvedValue(indexes);
+
+      const result = await service.listIndexes('testdb', 'users');
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.data[0].expireAfterSeconds).toBe(3600);
+        expect(result.data[0].partialFilterExpression).toEqual({ archived: false });
+      }
+    });
+
+    it('handles compound and special index types in keys', async () => {
+      const indexes = [
+        { v: 2, key: { lastName: 1, firstName: -1 }, name: 'name_compound' },
+        { v: 2, key: { description: 'text' }, name: 'description_text' },
+        { v: 2, key: { location: '2dsphere' }, name: 'location_2dsphere' },
+      ];
+      mockCollection.indexes.mockResolvedValue(indexes);
+
+      const result = await service.listIndexes('testdb', 'places');
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.data[0].key).toEqual({ lastName: 1, firstName: -1 });
+        expect(result.data[1].key).toEqual({ description: 'text' });
+        expect(result.data[2].key).toEqual({ location: '2dsphere' });
+      }
+    });
+
+    it('when not connected returns error', async () => {
+      requireClient.mockImplementation(() => {
+        throw new Error('Not connected');
+      });
+      const result = await service.listIndexes('testdb', 'users');
+      expect(result).toEqual({ ok: false, error: 'Not connected' });
+    });
+
+    it('surfaces driver errors verbatim', async () => {
+      mockCollection.indexes.mockRejectedValue(new Error('ns not found'));
+      const result = await service.listIndexes('testdb', 'users');
+      expect(result).toEqual({ ok: false, error: 'ns not found' });
     });
   });
 

--- a/src/main/mongo-service.ts
+++ b/src/main/mongo-service.ts
@@ -10,6 +10,7 @@ import type {
   FindResult,
   ImportOptions,
   DistinctResult,
+  IndexInfo,
 } from '../shared/types';
 
 export interface MongoServiceDeps {
@@ -337,6 +338,18 @@ export class MongoService {
       const sliced = truncated ? rawValues.slice(0, maxValues) : rawValues;
       const values = sliced.map((v) => EJSON.serialize(v));
       return { ok: true, data: { values, truncated } };
+    } catch (err) {
+      return { ok: false, error: (err as Error).message };
+    }
+  }
+
+  async listIndexes(dbName: string, collName: string): Promise<Result<IndexInfo[]>> {
+    try {
+      const client = this.conn.requireClient();
+      const collection = client.db(dbName).collection(collName);
+      const rawIndexes = await collection.indexes();
+      const data = rawIndexes.map((idx) => EJSON.serialize(idx) as unknown as IndexInfo);
+      return { ok: true, data };
     } catch (err) {
       return { ok: false, error: (err as Error).message };
     }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -9,6 +9,7 @@ import type {
   QueryHistoryEntry,
   PickedFile,
   DistinctResult,
+  IndexInfo,
   OperationKind,
   OperationStatus,
   OperationId,
@@ -38,6 +39,7 @@ interface MongoApi {
   onConnectionState(cb: (state: ConnectionState) => void): () => void;
   listDatabases(): Promise<Result<DbInfo[]>>;
   listCollections(db: string): Promise<Result<CollectionInfo[]>>;
+  listIndexes(db: string, collection: string): Promise<Result<IndexInfo[]>>;
   find(db: string, collection: string, opts: FindOpts): Promise<Result<FindResult>>;
   count(db: string, collection: string, filter?: Record<string, unknown>): Promise<Result<number>>;
   aggregate(

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -10,6 +10,7 @@ import type {
   QueryHistoryEntry,
   PickedFile,
   DistinctResult,
+  IndexInfo,
   OperationParams,
   OperationId,
   OperationRecord,
@@ -38,6 +39,8 @@ export function createApi(ipc: IpcLike) {
     listDatabases: (): Promise<Result<DbInfo[]>> => ipc.invoke('mongo:list-databases') as Promise<Result<DbInfo[]>>,
     listCollections: (db: string): Promise<Result<CollectionInfo[]>> =>
       ipc.invoke('mongo:list-collections', db) as Promise<Result<CollectionInfo[]>>,
+    listIndexes: (db: string, collection: string): Promise<Result<IndexInfo[]>> =>
+      ipc.invoke('mongo:list-indexes', db, collection) as Promise<Result<IndexInfo[]>>,
     find: (db: string, collection: string, opts: FindOpts): Promise<Result<FindResult>> =>
       ipc.invoke('mongo:find', db, collection, opts) as Promise<Result<FindResult>>,
     count: (db: string, collection: string, filter?: Record<string, unknown>): Promise<Result<number>> =>

--- a/src/renderer/src/components/IndexesDialog.tsx
+++ b/src/renderer/src/components/IndexesDialog.tsx
@@ -1,0 +1,90 @@
+import { useEffect, useState } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from './ui/dialog';
+import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from './ui/table';
+import { Loader } from './Loader';
+import type { IndexInfo } from '../../../shared/types';
+
+interface IndexesDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  db: string;
+  collection: string;
+}
+
+function formatKeyValue(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number') return String(value);
+  if (typeof value === 'boolean') return String(value);
+  return JSON.stringify(value);
+}
+
+function IndexesDialogBody({ db, collection }: { db: string; collection: string }) {
+  const [indexes, setIndexes] = useState<IndexInfo[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void window.api.listIndexes(db, collection).then((result) => {
+      if (cancelled) return;
+      setLoading(false);
+      if (result.ok) {
+        setIndexes(result.data);
+      } else {
+        setError(result.error);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [db, collection]);
+
+  if (loading) return <Loader className="py-8" />;
+  if (error !== null) return <p className="text-sm text-destructive">{error}</p>;
+  if (indexes === null || indexes.length === 0) {
+    return <p className="text-sm text-muted-foreground">No indexes.</p>;
+  }
+
+  return (
+    <div className="max-h-[60vh] overflow-y-auto rounded-md border border-input">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Name</TableHead>
+            <TableHead>Keys</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {indexes.map((idx) => (
+            <TableRow key={idx.name}>
+              <TableCell className="font-medium align-top">{idx.name}</TableCell>
+              <TableCell className="font-mono text-xs whitespace-pre">
+                {Object.entries(idx.key)
+                  .map(([field, value]) => `${field}: ${formatKeyValue(value)}`)
+                  .join('\n')}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
+export function IndexesDialog({ open, onOpenChange, db, collection }: IndexesDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Indexes</DialogTitle>
+          <DialogDescription>
+            <span className="font-medium text-foreground">{collection}</span>
+          </DialogDescription>
+        </DialogHeader>
+        {open && <IndexesDialogBody db={db} collection={collection} />}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/renderer/src/components/Sidebar.tsx
+++ b/src/renderer/src/components/Sidebar.tsx
@@ -4,10 +4,11 @@ import { ScrollArea } from './ui/scroll-area';
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from './ui/collapsible';
 import { Button } from './ui/button';
 import { Loader } from './Loader';
-import { Unplug, Download, EllipsisVertical, Upload, X, Trash2, RefreshCw } from 'lucide-react';
+import { Unplug, Download, EllipsisVertical, Upload, X, Trash2, RefreshCw, KeyRound } from 'lucide-react';
 import { Menu } from '@base-ui/react/menu';
 import { toast } from 'sonner';
 import { ImportDialog } from './ImportDialog';
+import { IndexesDialog } from './IndexesDialog';
 import { McpStatusPill } from './McpStatusPill';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from './ui/dialog';
 import { Input } from './ui/input';
@@ -31,6 +32,7 @@ interface CollectionRowProps {
 function CollectionRow({ dbName, coll, isSelected, onSelect }: CollectionRowProps) {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [confirmText, setConfirmText] = useState('');
+  const [indexesOpen, setIndexesOpen] = useState(false);
 
   const exp = useOperation('export-collection');
   const exporting = exp.status === 'running' || exp.status === 'pending';
@@ -142,6 +144,16 @@ function CollectionRow({ dbName, coll, isSelected, onSelect }: CollectionRowProp
                       Export
                     </Menu.Item>
                     <Menu.Item
+                      className="flex items-center gap-2 rounded-sm px-2 py-1.5 text-xs cursor-pointer outline-hidden hover:bg-accent hover:text-accent-foreground data-highlighted:bg-accent data-highlighted:text-accent-foreground"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setIndexesOpen(true);
+                      }}
+                    >
+                      <KeyRound className="h-3 w-3" />
+                      Indexes
+                    </Menu.Item>
+                    <Menu.Item
                       className="flex items-center gap-2 rounded-sm px-2 py-1.5 text-xs cursor-pointer outline-hidden text-destructive hover:bg-destructive/10 data-highlighted:bg-destructive/10"
                       onClick={(e) => {
                         e.stopPropagation();
@@ -189,6 +201,7 @@ function CollectionRow({ dbName, coll, isSelected, onSelect }: CollectionRowProp
           </DialogFooter>
         </DialogContent>
       </Dialog>
+      <IndexesDialog open={indexesOpen} onOpenChange={setIndexesOpen} db={dbName} collection={coll.name} />
     </>
   );
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -73,6 +73,12 @@ export interface DistinctResult {
   truncated: boolean;
 }
 
+export interface IndexInfo {
+  name: string;
+  key: Record<string, unknown>;
+  [k: string]: unknown;
+}
+
 export type ConnectionState =
   | { status: 'disconnected' }
   | { status: 'connecting'; uri: string }


### PR DESCRIPTION
### What does this PR do?

## Problem Statement

When working with a MongoDB collection in mongo-buddy, I have no way to see what indexes exist on it. I have to drop to a separate tool (mongosh, Compass) to check whether a query is going to hit an index, whether a uniqueness constraint is in place, or whether a TTL is configured. The same gap exists for an LLM agent driving mongo-buddy through MCP — it can sample fields and run queries but cannot reason about index coverage.

## Solution

Surface the existing indexes on a collection in two places:

1. **GUI**: a new "Indexes" entry in the per-collection menu in the sidebar (next to Export / Delete) opens a modal dialog that lists every index on that collection with its name and key spec.
2. **MCP**: a new `list_indexes` tool that returns the raw index documents from the MongoDB driver, so an agent can inspect any index property (unique, sparse, partial filter, TTL, etc.).

This PR is read-only. Creating and dropping indexes is a follow-up.

## User Stories

### Changes

- [x] #40 List indexes: backend + MCP tracer bullet
- [x] #41 List indexes: GUI dialog + sidebar menu

### Related issues

Closes #39

### How to test



### Additional notes

Generated by [Ralph Issues](https://github.com/richtabor/agent-skills).