### PR TITLE
Round-trip indexes through collection export/import

### DIFF
--- a/src/main/adapters/fs-sink.ts
+++ b/src/main/adapters/fs-sink.ts
@@ -1,5 +1,5 @@
 import { createReadStream, createWriteStream } from 'fs';
-import { unlink, writeFile } from 'fs/promises';
+import { readFile, unlink, writeFile } from 'fs/promises';
 import path from 'path';
 import { createGunzip, createGzip } from 'zlib';
 import type { FilesystemSinkPort, GunzipSource, GzipSink } from '../operation-registry';
@@ -59,6 +59,15 @@ export function createFsSinkAdapter(): FilesystemSinkPort {
 
     async writeIndexesSidecar(filePath: string, json: string): Promise<void> {
       await writeFile(filePath, json, 'utf8');
+    },
+
+    async readIndexesSidecar(filePath: string): Promise<string | null> {
+      try {
+        return await readFile(filePath, 'utf8');
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+        throw err;
+      }
     },
   };
 }

--- a/src/main/adapters/fs-sink.ts
+++ b/src/main/adapters/fs-sink.ts
@@ -1,8 +1,11 @@
 import { createReadStream, createWriteStream } from 'fs';
-import { unlink } from 'fs/promises';
+import { unlink, writeFile } from 'fs/promises';
 import path from 'path';
 import { createGunzip, createGzip } from 'zlib';
 import type { FilesystemSinkPort, GunzipSource, GzipSink } from '../operation-registry';
+
+const DATA_SUFFIX = '.bson.gz';
+const SIDECAR_SUFFIX = '.indexes.json';
 
 export function createFsSinkAdapter(): FilesystemSinkPort {
   return {
@@ -44,7 +47,18 @@ export function createFsSinkAdapter(): FilesystemSinkPort {
     },
 
     joinExportFilename(dir: string, base: string): string {
-      return path.join(dir, `${base}.bson.gz`);
+      return path.join(dir, `${base}${DATA_SUFFIX}`);
+    },
+
+    indexesSidecarPath(dataFilePath: string): string {
+      if (!dataFilePath.endsWith(DATA_SUFFIX)) {
+        throw new Error(`Expected path ending in ${DATA_SUFFIX}, got: ${dataFilePath}`);
+      }
+      return dataFilePath.slice(0, -DATA_SUFFIX.length) + SIDECAR_SUFFIX;
+    },
+
+    async writeIndexesSidecar(filePath: string, json: string): Promise<void> {
+      await writeFile(filePath, json, 'utf8');
     },
   };
 }

--- a/src/main/index-spec.test.ts
+++ b/src/main/index-spec.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { sanitizeForExport } from './index-spec';
+import { EJSON } from 'bson';
+import { sanitizeForExport, parseAndValidateSidecar, pickIndexesToCreate } from './index-spec';
 
 describe('sanitizeForExport', () => {
   it('drops the _id_ entry', () => {
@@ -104,5 +105,115 @@ describe('sanitizeForExport', () => {
     const input = [{ v: 2, key: { x: 1 }, name: 'x_1' }];
     const out = sanitizeForExport(input);
     expect(out).not.toBe(input);
+  });
+});
+
+describe('parseAndValidateSidecar', () => {
+  it('round-trips a normal sanitized array of specs', () => {
+    const specs = [
+      { key: { email: 1 }, name: 'email_1', unique: true },
+      { key: { name: 1 }, name: 'name_1', sparse: true },
+    ];
+    const json = JSON.stringify(EJSON.serialize(specs));
+    const result = parseAndValidateSidecar(json);
+    expect(result).toEqual(specs);
+  });
+
+  it('throws on non-JSON input', () => {
+    expect(() => parseAndValidateSidecar('not json {')).toThrow(/JSON|parse/i);
+  });
+
+  it("throws on JSON that isn't an array", () => {
+    expect(() => parseAndValidateSidecar(JSON.stringify({ key: { x: 1 }, name: 'x_1' }))).toThrow(/array/i);
+  });
+
+  it('throws on entries missing name', () => {
+    const json = JSON.stringify([{ key: { x: 1 } }]);
+    expect(() => parseAndValidateSidecar(json)).toThrow(/name/i);
+  });
+
+  it('throws on entries with non-string name', () => {
+    const json = JSON.stringify([{ key: { x: 1 }, name: 123 }]);
+    expect(() => parseAndValidateSidecar(json)).toThrow(/name/i);
+  });
+
+  it('throws on entries missing key', () => {
+    const json = JSON.stringify([{ name: 'x_1' }]);
+    expect(() => parseAndValidateSidecar(json)).toThrow(/key/i);
+  });
+
+  it('throws on entries with non-object key', () => {
+    const json = JSON.stringify([{ name: 'x_1', key: 'not-an-object' }]);
+    expect(() => parseAndValidateSidecar(json)).toThrow(/key/i);
+  });
+
+  it('throws on entries with null key', () => {
+    const json = JSON.stringify([{ name: 'x_1', key: null }]);
+    expect(() => parseAndValidateSidecar(json)).toThrow(/key/i);
+  });
+
+  it('correctly EJSON-deserializes BSON-typed values inside partialFilterExpression', () => {
+    const date = new Date('2026-01-01T00:00:00Z');
+    const specs = [
+      {
+        key: { createdAt: 1 },
+        name: 'recent_only',
+        partialFilterExpression: { createdAt: { $gt: date } },
+      },
+    ];
+    const json = JSON.stringify(EJSON.serialize(specs));
+    const result = parseAndValidateSidecar(json);
+    expect(result).toHaveLength(1);
+    const filter = result[0].partialFilterExpression as { createdAt: { $gt: unknown } };
+    expect(filter.createdAt.$gt).toBeInstanceOf(Date);
+    expect((filter.createdAt.$gt as Date).getTime()).toBe(date.getTime());
+  });
+});
+
+describe('pickIndexesToCreate', () => {
+  const specA = { key: { a: 1 }, name: 'a_1' };
+  const specB = { key: { b: 1 }, name: 'b_1' };
+  const specC = { key: { c: 1 }, name: 'c_1' };
+
+  it('returns all specs when dropExisting is true', () => {
+    const out = pickIndexesToCreate([specA, specB], ['a_1', 'b_1', 'other'], true);
+    expect(out).toEqual([specA, specB]);
+  });
+
+  it('filters out specs whose name appears in existingIndexNames when dropExisting is false', () => {
+    const out = pickIndexesToCreate([specA, specB, specC], ['a_1'], false);
+    expect(out).toEqual([specB, specC]);
+  });
+
+  it('returns empty array when every spec name is already present', () => {
+    const out = pickIndexesToCreate([specA, specB], ['a_1', 'b_1', '_id_'], false);
+    expect(out).toEqual([]);
+  });
+
+  it('returns all specs when existingIndexNames is empty (dropExisting=false)', () => {
+    const out = pickIndexesToCreate([specA, specB], [], false);
+    expect(out).toEqual([specA, specB]);
+  });
+
+  it('uses case-sensitive name comparison', () => {
+    const out = pickIndexesToCreate([specA], ['A_1'], false);
+    expect(out).toEqual([specA]);
+  });
+
+  it('does not mutate inputs', () => {
+    const specs = [specA, specB];
+    const existing = ['a_1'];
+    const specsSnap = JSON.parse(JSON.stringify(specs));
+    const existingSnap = [...existing];
+    pickIndexesToCreate(specs, existing, false);
+    expect(specs).toEqual(specsSnap);
+    expect(existing).toEqual(existingSnap);
+  });
+
+  it('returns a fresh array (different reference) even when dropExisting is true', () => {
+    const specs = [specA, specB];
+    const out = pickIndexesToCreate(specs, [], true);
+    expect(out).not.toBe(specs);
+    expect(out).toEqual(specs);
   });
 });

--- a/src/main/index-spec.test.ts
+++ b/src/main/index-spec.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeForExport } from './index-spec';
+
+describe('sanitizeForExport', () => {
+  it('drops the _id_ entry', () => {
+    const input = [
+      { v: 2, key: { _id: 1 }, name: '_id_' },
+      { v: 2, key: { email: 1 }, name: 'email_1', unique: true },
+    ];
+    const out = sanitizeForExport(input);
+    expect(out).toHaveLength(1);
+    expect(out[0].name).toBe('email_1');
+  });
+
+  it('strips every denylisted field (v, ns, background, textIndexVersion, 2dsphereIndexVersion)', () => {
+    const input = [
+      {
+        v: 2,
+        ns: 'mydb.users',
+        background: true,
+        textIndexVersion: 3,
+        '2dsphereIndexVersion': 3,
+        key: { email: 1 },
+        name: 'email_1',
+        unique: true,
+      },
+    ];
+    const out = sanitizeForExport(input);
+    expect(out).toHaveLength(1);
+    const spec = out[0];
+    expect(spec).not.toHaveProperty('v');
+    expect(spec).not.toHaveProperty('ns');
+    expect(spec).not.toHaveProperty('background');
+    expect(spec).not.toHaveProperty('textIndexVersion');
+    expect(spec).not.toHaveProperty('2dsphereIndexVersion');
+    expect(spec.name).toBe('email_1');
+    expect(spec.key).toEqual({ email: 1 });
+    expect(spec.unique).toBe(true);
+  });
+
+  it('preserves user spec fields (unique, sparse, expireAfterSeconds, partialFilterExpression, collation, weights, default_language, language_override, hidden, wildcardProjection)', () => {
+    const input = [
+      {
+        v: 2,
+        key: { a: 1 },
+        name: 'kitchen_sink',
+        unique: true,
+        sparse: true,
+        expireAfterSeconds: 3600,
+        partialFilterExpression: { archived: false },
+        collation: { locale: 'en', strength: 2 },
+        weights: { title: 10, body: 1 },
+        default_language: 'english',
+        language_override: 'lang',
+        hidden: true,
+        wildcardProjection: { 'a.b': 1 },
+      },
+    ];
+    const out = sanitizeForExport(input);
+    expect(out).toHaveLength(1);
+    const spec = out[0];
+    expect(spec.unique).toBe(true);
+    expect(spec.sparse).toBe(true);
+    expect(spec.expireAfterSeconds).toBe(3600);
+    expect(spec.partialFilterExpression).toEqual({ archived: false });
+    expect(spec.collation).toEqual({ locale: 'en', strength: 2 });
+    expect(spec.weights).toEqual({ title: 10, body: 1 });
+    expect(spec.default_language).toBe('english');
+    expect(spec.language_override).toBe('lang');
+    expect(spec.hidden).toBe(true);
+    expect(spec.wildcardProjection).toEqual({ 'a.b': 1 });
+  });
+
+  it('is a no-op (empty array) when there are no user indexes — only _id_', () => {
+    const input = [{ v: 2, key: { _id: 1 }, name: '_id_' }];
+    const out = sanitizeForExport(input);
+    expect(out).toEqual([]);
+  });
+
+  it('returns an empty array for an empty input', () => {
+    expect(sanitizeForExport([])).toEqual([]);
+  });
+
+  it('does not mutate the input array or its entries', () => {
+    const entry = {
+      v: 2,
+      ns: 'mydb.users',
+      background: true,
+      key: { email: 1 },
+      name: 'email_1',
+      unique: true,
+    };
+    const input = [entry, { v: 2, key: { _id: 1 }, name: '_id_' }];
+    const inputSnapshot = JSON.parse(JSON.stringify(input));
+    sanitizeForExport(input);
+    expect(input).toEqual(inputSnapshot);
+    // entry reference still has its original fields
+    expect(entry.v).toBe(2);
+    expect(entry.ns).toBe('mydb.users');
+    expect(entry.background).toBe(true);
+  });
+
+  it('returns a fresh array (different reference)', () => {
+    const input = [{ v: 2, key: { x: 1 }, name: 'x_1' }];
+    const out = sanitizeForExport(input);
+    expect(out).not.toBe(input);
+  });
+});

--- a/src/main/index-spec.ts
+++ b/src/main/index-spec.ts
@@ -1,3 +1,4 @@
+import { EJSON } from 'bson';
 import type { IndexInfo } from '../shared/types';
 
 export type IndexSpec = IndexInfo;
@@ -18,4 +19,44 @@ export function sanitizeForExport(rawIndexes: ReadonlyArray<Record<string, unkno
     result.push(cleaned as IndexSpec);
   }
   return result;
+}
+
+export function parseAndValidateSidecar(rawJsonString: string): IndexSpec[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawJsonString);
+  } catch (err) {
+    throw new Error(`Invalid indexes sidecar: failed to parse JSON: ${(err as Error).message}`, { cause: err });
+  }
+
+  const deserialized = EJSON.deserialize(parsed as Record<string, unknown>) as unknown;
+  if (!Array.isArray(deserialized)) {
+    throw new Error('Invalid indexes sidecar: expected an array of index specs');
+  }
+
+  for (let i = 0; i < deserialized.length; i++) {
+    const entry = deserialized[i];
+    if (entry === null || typeof entry !== 'object') {
+      throw new Error(`Invalid indexes sidecar: entry at index ${i} is not an object`);
+    }
+    const e = entry as Record<string, unknown>;
+    if (typeof e.name !== 'string') {
+      throw new Error(`Invalid indexes sidecar: entry at index ${i} is missing a string "name"`);
+    }
+    if (e.key === null || typeof e.key !== 'object' || Array.isArray(e.key)) {
+      throw new Error(`Invalid indexes sidecar: entry at index ${i} ("${e.name}") is missing an object "key"`);
+    }
+  }
+
+  return deserialized as IndexSpec[];
+}
+
+export function pickIndexesToCreate(
+  specs: ReadonlyArray<IndexSpec>,
+  existingIndexNames: ReadonlyArray<string>,
+  dropExisting: boolean
+): IndexSpec[] {
+  if (dropExisting) return specs.slice();
+  const existing = new Set(existingIndexNames);
+  return specs.filter((s) => !existing.has(s.name));
 }

--- a/src/main/index-spec.ts
+++ b/src/main/index-spec.ts
@@ -1,0 +1,21 @@
+import type { IndexInfo } from '../shared/types';
+
+export type IndexSpec = IndexInfo;
+
+const DRIVER_ONLY_FIELDS = new Set(['v', 'ns', 'background', 'textIndexVersion', '2dsphereIndexVersion']);
+
+const ID_INDEX_NAME = '_id_';
+
+export function sanitizeForExport(rawIndexes: ReadonlyArray<Record<string, unknown>>): IndexSpec[] {
+  const result: IndexSpec[] = [];
+  for (const idx of rawIndexes) {
+    if (idx.name === ID_INDEX_NAME) continue;
+    const cleaned: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(idx)) {
+      if (DRIVER_ONLY_FIELDS.has(key)) continue;
+      cleaned[key] = value;
+    }
+    result.push(cleaned as IndexSpec);
+  }
+  return result;
+}

--- a/src/main/mongo-service.ts
+++ b/src/main/mongo-service.ts
@@ -12,7 +12,8 @@ import type {
   DistinctResult,
   IndexInfo,
 } from '../shared/types';
-import { sanitizeForExport, type IndexSpec } from './index-spec';
+import type { IndexDescription } from 'mongodb';
+import { pickIndexesToCreate, sanitizeForExport, type IndexSpec } from './index-spec';
 
 export interface MongoServiceDeps {
   conn: Pick<ConnectionManager, 'requireClient'>;
@@ -363,6 +364,38 @@ export class MongoService {
       const rawIndexes = await collection.indexes();
       const data = sanitizeForExport(rawIndexes as Record<string, unknown>[]);
       return { ok: true, data };
+    } catch (err) {
+      return { ok: false, error: (err as Error).message };
+    }
+  }
+
+  async applyImportedIndexes(
+    dbName: string,
+    collName: string,
+    specs: IndexSpec[],
+    opts: { dropExisting: boolean }
+  ): Promise<Result<undefined>> {
+    try {
+      const client = this.conn.requireClient();
+      const collection = client.db(dbName).collection(collName);
+
+      let toCreate: IndexSpec[];
+      if (opts.dropExisting) {
+        // dropIndexes() leaves the auto _id_ index alone.
+        await collection.dropIndexes();
+        toCreate = pickIndexesToCreate(specs, [], true);
+      } else {
+        const existing = await collection.indexes();
+        const existingNames = existing
+          .map((idx) => (idx as { name?: unknown }).name)
+          .filter((n): n is string => typeof n === 'string');
+        toCreate = pickIndexesToCreate(specs, existingNames, false);
+      }
+
+      if (toCreate.length > 0) {
+        await collection.createIndexes(toCreate as unknown as IndexDescription[]);
+      }
+      return { ok: true, data: undefined };
     } catch (err) {
       return { ok: false, error: (err as Error).message };
     }

--- a/src/main/mongo-service.ts
+++ b/src/main/mongo-service.ts
@@ -12,6 +12,7 @@ import type {
   DistinctResult,
   IndexInfo,
 } from '../shared/types';
+import { sanitizeForExport, type IndexSpec } from './index-spec';
 
 export interface MongoServiceDeps {
   conn: Pick<ConnectionManager, 'requireClient'>;
@@ -349,6 +350,18 @@ export class MongoService {
       const collection = client.db(dbName).collection(collName);
       const rawIndexes = await collection.indexes();
       const data = rawIndexes.map((idx) => EJSON.serialize(idx) as unknown as IndexInfo);
+      return { ok: true, data };
+    } catch (err) {
+      return { ok: false, error: (err as Error).message };
+    }
+  }
+
+  async getExportableIndexes(dbName: string, collName: string): Promise<Result<IndexSpec[]>> {
+    try {
+      const client = this.conn.requireClient();
+      const collection = client.db(dbName).collection(collName);
+      const rawIndexes = await collection.indexes();
+      const data = sanitizeForExport(rawIndexes as Record<string, unknown>[]);
       return { ok: true, data };
     } catch (err) {
       return { ok: false, error: (err as Error).message };

--- a/src/main/operation-registry.test.ts
+++ b/src/main/operation-registry.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Writable, Readable } from 'stream';
 import { createOperationRegistry } from './operation-registry';
 import type { MongoServicePort } from './operation-registry';
+import type { IndexSpec } from './index-spec';
 import { MongoService } from './mongo-service';
 import type { OperationRecord, OperationParams, Result, ImportOptions, CollectionInfo } from '../shared/types';
 
@@ -38,7 +39,7 @@ type ImportCall = {
  * this file (rather than extracting) so test intent stays local.
  */
 
-function makeFsPort() {
+function makeFsPort(overrides: { writeIndexesSidecar?: (filePath: string, json: string) => Promise<void> } = {}) {
   const sinks: Array<{
     filePath: string;
     writes: Buffer[];
@@ -46,6 +47,7 @@ function makeFsPort() {
     destroyed: boolean;
   }> = [];
   const sources: Array<{ filePath: string; destroyed: boolean }> = [];
+  const sidecarWrites: Array<{ filePath: string; json: string }> = [];
 
   return {
     writeGzipSink: vi.fn((filePath: string) => {
@@ -79,8 +81,22 @@ function makeFsPort() {
       };
     }),
     joinExportFilename: (dir: string, base: string): string => `${dir}/${base}.bson.gz`,
+    indexesSidecarPath: (dataFilePath: string): string => {
+      if (!dataFilePath.endsWith('.bson.gz')) {
+        throw new Error(`Expected .bson.gz suffix, got: ${dataFilePath}`);
+      }
+      return dataFilePath.slice(0, -'.bson.gz'.length) + '.indexes.json';
+    },
+    writeIndexesSidecar: vi.fn(async (filePath: string, json: string): Promise<void> => {
+      if (overrides.writeIndexesSidecar) {
+        await overrides.writeIndexesSidecar(filePath, json);
+        return;
+      }
+      sidecarWrites.push({ filePath, json });
+    }),
     _sinks: sinks,
     _sources: sources,
+    _sidecarWrites: sidecarWrites,
   };
 }
 
@@ -98,6 +114,7 @@ function makeMongoPort(
     exportCollection?: (call: ExportCall) => Promise<Result<number>>;
     importCollection?: (call: ImportCall) => Promise<Result<{ inserted: number; skipped: number }>>;
     listCollections?: (db: string) => Promise<Result<CollectionInfo[]>>;
+    getExportableIndexes?: (db: string, coll: string) => Promise<Result<IndexSpec[]>>;
   } = {}
 ) {
   return {
@@ -144,6 +161,10 @@ function makeMongoPort(
     ),
     listCollections: vi.fn((db: string): Promise<Result<CollectionInfo[]>> => {
       if (overrides.listCollections) return overrides.listCollections(db);
+      return Promise.resolve({ ok: true, data: [] });
+    }),
+    getExportableIndexes: vi.fn((db: string, coll: string): Promise<Result<IndexSpec[]>> => {
+      if (overrides.getExportableIndexes) return overrides.getExportableIndexes(db, coll);
       return Promise.resolve({ ok: true, data: [] });
     }),
   };
@@ -227,6 +248,83 @@ describe('OperationRegistry', () => {
       const callArgs = mongo.exportCollection.mock.calls[0];
       expect(callArgs[0]).toBe('mydb');
       expect(callArgs[1]).toBe('users');
+    });
+  });
+
+  describe('export-collection sidecar', () => {
+    it('writes the indexes sidecar after sink.finalize() with EJSON-serialized specs', async () => {
+      const fs = makeFsPort();
+      const dialog = makeDialogPort({ savePath: '/tmp/users.bson.gz' });
+      const mongo = makeMongoPort({
+        getExportableIndexes: async () => ({
+          ok: true,
+          data: [{ key: { email: 1 }, name: 'email_1', unique: true }],
+        }),
+      });
+      const { emits, emit } = makeEmitSpy();
+      const registry = createOperationRegistry({ mongo, fs, dialog, emit });
+
+      registry.start({ kind: 'export-collection', db: 'mydb', collection: 'users' });
+      const terminal = await waitForTerminal(emits);
+      expect(terminal.status).toBe('succeeded');
+      expect(terminal.warning).toBeUndefined();
+
+      expect(fs._sidecarWrites).toHaveLength(1);
+      expect(fs._sidecarWrites[0].filePath).toBe('/tmp/users.indexes.json');
+      const parsed = JSON.parse(fs._sidecarWrites[0].json);
+      expect(parsed).toEqual([{ key: { email: 1 }, name: 'email_1', unique: true }]);
+      expect(mongo.getExportableIndexes).toHaveBeenCalledWith('mydb', 'users');
+    });
+
+    it('skips sidecar write when user cancelled the save dialog', async () => {
+      const fs = makeFsPort();
+      const dialog = makeDialogPort({ savePath: null });
+      const mongo = makeMongoPort();
+      const { emits, emit } = makeEmitSpy();
+      const registry = createOperationRegistry({ mongo, fs, dialog, emit });
+
+      registry.start({ kind: 'export-collection', db: 'mydb', collection: 'users' });
+      const terminal = await waitForTerminal(emits);
+      expect(terminal.status).toBe('succeeded');
+      expect(fs._sidecarWrites).toHaveLength(0);
+      expect(mongo.getExportableIndexes).not.toHaveBeenCalled();
+    });
+
+    it('still succeeds with a warning when sidecar write fails', async () => {
+      const fs = makeFsPort({
+        writeIndexesSidecar: async () => {
+          throw new Error('EACCES: read-only directory');
+        },
+      });
+      const dialog = makeDialogPort({ savePath: '/tmp/users.bson.gz' });
+      const mongo = makeMongoPort({
+        getExportableIndexes: async () => ({ ok: true, data: [{ key: { x: 1 }, name: 'x_1' }] }),
+      });
+      const { emits, emit } = makeEmitSpy();
+      const registry = createOperationRegistry({ mongo, fs, dialog, emit });
+
+      registry.start({ kind: 'export-collection', db: 'mydb', collection: 'users' });
+      const terminal = await waitForTerminal(emits);
+      expect(terminal.status).toBe('succeeded');
+      expect(terminal.warning).toMatch(/EACCES/);
+      // Data file finalized regardless
+      expect(fs._sinks[0].finalized).toBe(true);
+    });
+
+    it('still succeeds with a warning when reading the indexes fails', async () => {
+      const fs = makeFsPort();
+      const dialog = makeDialogPort({ savePath: '/tmp/users.bson.gz' });
+      const mongo = makeMongoPort({
+        getExportableIndexes: async () => ({ ok: false, error: 'ns not found' }),
+      });
+      const { emits, emit } = makeEmitSpy();
+      const registry = createOperationRegistry({ mongo, fs, dialog, emit });
+
+      registry.start({ kind: 'export-collection', db: 'mydb', collection: 'users' });
+      const terminal = await waitForTerminal(emits);
+      expect(terminal.status).toBe('succeeded');
+      expect(terminal.warning).toMatch(/ns not found/);
+      expect(fs._sidecarWrites).toHaveLength(0);
     });
   });
 

--- a/src/main/operation-registry.test.ts
+++ b/src/main/operation-registry.test.ts
@@ -486,6 +486,166 @@ describe('OperationRegistry', () => {
     });
   });
 
+  describe('export-database sidecar', () => {
+    it('writes one indexes sidecar per collection, no warning on success', async () => {
+      const fs = makeFsPort();
+      const dialog = makeDialogPort({ folderPath: '/tmp/out' });
+      const mongo = makeMongoPort({
+        listCollections: async () => ({
+          ok: true,
+          data: [
+            { name: 'a', type: 'collection' },
+            { name: 'b', type: 'collection' },
+          ],
+        }),
+        exportCollection: async () => ({ ok: true, data: 1 }),
+        getExportableIndexes: async (_db, coll) => ({
+          ok: true,
+          data: [{ key: { x: 1 }, name: `${coll}_x_1` }],
+        }),
+      });
+      const { emits, emit } = makeEmitSpy();
+      const registry = createOperationRegistry({ mongo, fs, dialog, emit });
+
+      registry.start({ kind: 'export-database', db: 'mydb' });
+      const terminal = await waitForTerminal(emits);
+
+      expect(terminal.status).toBe('succeeded');
+      expect(terminal.warning).toBeUndefined();
+
+      expect(fs._sidecarWrites.map((s) => s.filePath)).toEqual(['/tmp/out/a.indexes.json', '/tmp/out/b.indexes.json']);
+      expect(JSON.parse(fs._sidecarWrites[0].json)).toEqual([{ key: { x: 1 }, name: 'a_x_1' }]);
+      expect(JSON.parse(fs._sidecarWrites[1].json)).toEqual([{ key: { x: 1 }, name: 'b_x_1' }]);
+      expect(mongo.getExportableIndexes).toHaveBeenCalledTimes(2);
+    });
+
+    it('accumulates per-collection sidecar-write errors into a warning; other sidecars still written', async () => {
+      const written: string[] = [];
+      const fs = makeFsPort({
+        writeIndexesSidecar: async (filePath) => {
+          if (filePath === '/tmp/out/b.indexes.json') {
+            throw new Error('disk full');
+          }
+          written.push(filePath);
+        },
+      });
+      const dialog = makeDialogPort({ folderPath: '/tmp/out' });
+      const mongo = makeMongoPort({
+        listCollections: async () => ({
+          ok: true,
+          data: [
+            { name: 'a', type: 'collection' },
+            { name: 'b', type: 'collection' },
+            { name: 'c', type: 'collection' },
+          ],
+        }),
+        exportCollection: async () => ({ ok: true, data: 1 }),
+        getExportableIndexes: async () => ({ ok: true, data: [{ key: { x: 1 }, name: 'x_1' }] }),
+      });
+      const { emits, emit } = makeEmitSpy();
+      const registry = createOperationRegistry({ mongo, fs, dialog, emit });
+
+      registry.start({ kind: 'export-database', db: 'mydb' });
+      const terminal = await waitForTerminal(emits);
+
+      expect(terminal.status).toBe('succeeded');
+      expect(terminal.warning).toBeDefined();
+      expect(terminal.warning).toContain('b');
+      // a and c still got written
+      expect(written).toEqual(['/tmp/out/a.indexes.json', '/tmp/out/c.indexes.json']);
+      // all 3 data files were finalized
+      expect(fs._sinks.every((s) => s.finalized)).toBe(true);
+    });
+
+    it('lists multiple bad collections in a single accumulated warning', async () => {
+      const fs = makeFsPort({
+        writeIndexesSidecar: async (filePath) => {
+          if (filePath === '/tmp/out/b.indexes.json' || filePath === '/tmp/out/c.indexes.json') {
+            throw new Error('boom');
+          }
+        },
+      });
+      const dialog = makeDialogPort({ folderPath: '/tmp/out' });
+      const mongo = makeMongoPort({
+        listCollections: async () => ({
+          ok: true,
+          data: [
+            { name: 'a', type: 'collection' },
+            { name: 'b', type: 'collection' },
+            { name: 'c', type: 'collection' },
+          ],
+        }),
+        exportCollection: async () => ({ ok: true, data: 1 }),
+        getExportableIndexes: async () => ({ ok: true, data: [{ key: { x: 1 }, name: 'x_1' }] }),
+      });
+      const { emits, emit } = makeEmitSpy();
+      const registry = createOperationRegistry({ mongo, fs, dialog, emit });
+
+      registry.start({ kind: 'export-database', db: 'mydb' });
+      const terminal = await waitForTerminal(emits);
+
+      expect(terminal.status).toBe('succeeded');
+      expect(terminal.warning).toBeDefined();
+      // Extract the comma-separated names list and check exactly which collections appear
+      const match = /sidecar errors for:\s*(.*)$/.exec(terminal.warning ?? '');
+      expect(match).not.toBeNull();
+      const names = match![1].split(',').map((s) => s.trim());
+      expect(names).toEqual(['b', 'c']);
+    });
+
+    it('records a warning when getExportableIndexes fails for one collection', async () => {
+      const fs = makeFsPort();
+      const dialog = makeDialogPort({ folderPath: '/tmp/out' });
+      const mongo = makeMongoPort({
+        listCollections: async () => ({
+          ok: true,
+          data: [
+            { name: 'a', type: 'collection' },
+            { name: 'b', type: 'collection' },
+          ],
+        }),
+        exportCollection: async () => ({ ok: true, data: 1 }),
+        getExportableIndexes: async (_db, coll) =>
+          coll === 'a' ? { ok: false, error: 'ns not found' } : { ok: true, data: [] },
+      });
+      const { emits, emit } = makeEmitSpy();
+      const registry = createOperationRegistry({ mongo, fs, dialog, emit });
+
+      registry.start({ kind: 'export-database', db: 'mydb' });
+      const terminal = await waitForTerminal(emits);
+
+      expect(terminal.status).toBe('succeeded');
+      expect(terminal.warning).toBeDefined();
+      expect(terminal.warning).toContain('a');
+      // b's sidecar still got written
+      expect(fs._sidecarWrites.map((s) => s.filePath)).toEqual(['/tmp/out/b.indexes.json']);
+    });
+
+    it('data-export failure still fails the operation (sidecar errors do not change this)', async () => {
+      const fs = makeFsPort();
+      const dialog = makeDialogPort({ folderPath: '/tmp/out' });
+      const mongo = makeMongoPort({
+        listCollections: async () => ({
+          ok: true,
+          data: [
+            { name: 'a', type: 'collection' },
+            { name: 'b', type: 'collection' },
+          ],
+        }),
+        exportCollection: async ({ coll }) =>
+          coll === 'a' ? { ok: true, data: 1 } : { ok: false, error: 'disk read error' },
+      });
+      const { emits, emit } = makeEmitSpy();
+      const registry = createOperationRegistry({ mongo, fs, dialog, emit });
+
+      registry.start({ kind: 'export-database', db: 'mydb' });
+      const terminal = await waitForTerminal(emits);
+
+      expect(terminal.status).toBe('failed');
+      expect(terminal.error).toBe('disk read error');
+    });
+  });
+
   describe('enqueue guard', () => {
     it('rejects second start() with same scope key while in-flight; accepts after terminal', async () => {
       const fs = makeFsPort();

--- a/src/main/operation-registry.test.ts
+++ b/src/main/operation-registry.test.ts
@@ -39,7 +39,12 @@ type ImportCall = {
  * this file (rather than extracting) so test intent stays local.
  */
 
-function makeFsPort(overrides: { writeIndexesSidecar?: (filePath: string, json: string) => Promise<void> } = {}) {
+function makeFsPort(
+  overrides: {
+    writeIndexesSidecar?: (filePath: string, json: string) => Promise<void>;
+    readIndexesSidecar?: (filePath: string) => Promise<string | null>;
+  } = {}
+) {
   const sinks: Array<{
     filePath: string;
     writes: Buffer[];
@@ -94,6 +99,12 @@ function makeFsPort(overrides: { writeIndexesSidecar?: (filePath: string, json: 
       }
       sidecarWrites.push({ filePath, json });
     }),
+    readIndexesSidecar: vi.fn(async (filePath: string): Promise<string | null> => {
+      if (overrides.readIndexesSidecar) {
+        return overrides.readIndexesSidecar(filePath);
+      }
+      return null;
+    }),
     _sinks: sinks,
     _sources: sources,
     _sidecarWrites: sidecarWrites,
@@ -115,6 +126,12 @@ function makeMongoPort(
     importCollection?: (call: ImportCall) => Promise<Result<{ inserted: number; skipped: number }>>;
     listCollections?: (db: string) => Promise<Result<CollectionInfo[]>>;
     getExportableIndexes?: (db: string, coll: string) => Promise<Result<IndexSpec[]>>;
+    applyImportedIndexes?: (
+      db: string,
+      coll: string,
+      specs: IndexSpec[],
+      opts: { dropExisting: boolean }
+    ) => Promise<Result<undefined>>;
   } = {}
 ) {
   return {
@@ -167,6 +184,12 @@ function makeMongoPort(
       if (overrides.getExportableIndexes) return overrides.getExportableIndexes(db, coll);
       return Promise.resolve({ ok: true, data: [] });
     }),
+    applyImportedIndexes: vi.fn(
+      (db: string, coll: string, specs: IndexSpec[], opts: { dropExisting: boolean }): Promise<Result<undefined>> => {
+        if (overrides.applyImportedIndexes) return overrides.applyImportedIndexes(db, coll, specs, opts);
+        return Promise.resolve({ ok: true, data: undefined });
+      }
+    ),
   };
 }
 
@@ -380,6 +403,157 @@ describe('OperationRegistry', () => {
       expect(args[0]).toBe('mydb');
       expect(args[1]).toBe('users');
       expect(args[3]).toEqual({ onDuplicate: 'skip', clearFirst: false });
+    });
+  });
+
+  describe('import-collection sidecar', () => {
+    const importParams = (overrides: Partial<{ clearFirst: boolean }> = {}): OperationParams => ({
+      kind: 'import-collection',
+      db: 'mydb',
+      collection: 'users',
+      filePath: '/tmp/input.bson.gz',
+      options: { onDuplicate: 'skip', clearFirst: overrides.clearFirst ?? false },
+    });
+
+    it('missing sidecar: data import succeeds with a warning, applyImportedIndexes not called', async () => {
+      const fs = makeFsPort(); // default readIndexesSidecar returns null
+      const dialog = makeDialogPort();
+      const mongo = makeMongoPort();
+      const { emits, emit } = makeEmitSpy();
+      const registry = createOperationRegistry({ mongo, fs, dialog, emit });
+
+      registry.start(importParams());
+      const terminal = await waitForTerminal(emits);
+
+      expect(terminal.status).toBe('succeeded');
+      expect(terminal.warning).toBeDefined();
+      expect(terminal.warning).toMatch(/sidecar/i);
+      expect(mongo.applyImportedIndexes).not.toHaveBeenCalled();
+      expect(fs.readIndexesSidecar).toHaveBeenCalledWith('/tmp/input.indexes.json');
+    });
+
+    it('valid sidecar: applies indexes after data import with dropExisting=clearFirst', async () => {
+      const specs = [{ key: { email: 1 }, name: 'email_1', unique: true }];
+      const json = JSON.stringify(specs);
+      const fs = makeFsPort({ readIndexesSidecar: async () => json });
+      const dialog = makeDialogPort();
+      const mongo = makeMongoPort();
+      const { emits, emit } = makeEmitSpy();
+      const registry = createOperationRegistry({ mongo, fs, dialog, emit });
+
+      registry.start(importParams({ clearFirst: true }));
+      const terminal = await waitForTerminal(emits);
+
+      expect(terminal.status).toBe('succeeded');
+      expect(terminal.warning).toBeUndefined();
+      expect(mongo.applyImportedIndexes).toHaveBeenCalledTimes(1);
+      const callArgs = mongo.applyImportedIndexes.mock.calls[0];
+      expect(callArgs[0]).toBe('mydb');
+      expect(callArgs[1]).toBe('users');
+      expect(callArgs[2]).toEqual(specs);
+      expect(callArgs[3]).toEqual({ dropExisting: true });
+    });
+
+    it('valid sidecar with clearFirst=false: applies indexes with dropExisting=false', async () => {
+      const specs = [{ key: { x: 1 }, name: 'x_1' }];
+      const fs = makeFsPort({ readIndexesSidecar: async () => JSON.stringify(specs) });
+      const dialog = makeDialogPort();
+      const mongo = makeMongoPort();
+      const { emits, emit } = makeEmitSpy();
+      const registry = createOperationRegistry({ mongo, fs, dialog, emit });
+
+      registry.start(importParams({ clearFirst: false }));
+      const terminal = await waitForTerminal(emits);
+      expect(terminal.status).toBe('succeeded');
+      expect(mongo.applyImportedIndexes).toHaveBeenCalledTimes(1);
+      expect(mongo.applyImportedIndexes.mock.calls[0][3]).toEqual({ dropExisting: false });
+    });
+
+    it('malformed sidecar: fails before any data operation runs', async () => {
+      const fs = makeFsPort({ readIndexesSidecar: async () => 'not valid json {{{' });
+      const dialog = makeDialogPort();
+      const mongo = makeMongoPort();
+      const { emits, emit } = makeEmitSpy();
+      const registry = createOperationRegistry({ mongo, fs, dialog, emit });
+
+      registry.start(importParams({ clearFirst: true }));
+      const terminal = await waitForTerminal(emits);
+
+      expect(terminal.status).toBe('failed');
+      expect(terminal.error).toBeDefined();
+      // Critical: importCollection (which does deleteMany) must NOT have been called
+      expect(mongo.importCollection).not.toHaveBeenCalled();
+      expect(mongo.applyImportedIndexes).not.toHaveBeenCalled();
+    });
+
+    it('sidecar that is not an array: fails before any data operation runs', async () => {
+      const fs = makeFsPort({ readIndexesSidecar: async () => JSON.stringify({ not: 'an array' }) });
+      const dialog = makeDialogPort();
+      const mongo = makeMongoPort();
+      const { emits, emit } = makeEmitSpy();
+      const registry = createOperationRegistry({ mongo, fs, dialog, emit });
+
+      registry.start(importParams({ clearFirst: true }));
+      const terminal = await waitForTerminal(emits);
+
+      expect(terminal.status).toBe('failed');
+      expect(mongo.importCollection).not.toHaveBeenCalled();
+    });
+
+    it('index-create failure: marks op failed with inserted-count message', async () => {
+      const specs = [{ key: { email: 1 }, name: 'email_1', unique: true }];
+      const fs = makeFsPort({ readIndexesSidecar: async () => JSON.stringify(specs) });
+      const dialog = makeDialogPort();
+      const mongo = makeMongoPort({
+        importCollection: async () => ({ ok: true, data: { inserted: 42, skipped: 0 } }),
+        applyImportedIndexes: async () => ({ ok: false, error: 'duplicate key violation' }),
+      });
+      const { emits, emit } = makeEmitSpy();
+      const registry = createOperationRegistry({ mongo, fs, dialog, emit });
+
+      registry.start(importParams({ clearFirst: false }));
+      const terminal = await waitForTerminal(emits);
+
+      expect(terminal.status).toBe('failed');
+      expect(terminal.error).toMatch(/duplicate key violation/);
+      expect(terminal.error).toMatch(/42/);
+    });
+
+    it('data-import failure: does not call applyImportedIndexes', async () => {
+      const specs = [{ key: { x: 1 }, name: 'x_1' }];
+      const fs = makeFsPort({ readIndexesSidecar: async () => JSON.stringify(specs) });
+      const dialog = makeDialogPort();
+      const mongo = makeMongoPort({
+        importCollection: async () => ({ ok: false, error: 'bson decode failed' }),
+      });
+      const { emits, emit } = makeEmitSpy();
+      const registry = createOperationRegistry({ mongo, fs, dialog, emit });
+
+      registry.start(importParams());
+      const terminal = await waitForTerminal(emits);
+
+      expect(terminal.status).toBe('failed');
+      expect(terminal.error).toBe('bson decode failed');
+      expect(mongo.applyImportedIndexes).not.toHaveBeenCalled();
+    });
+
+    it('readIndexesSidecar throwing a non-ENOENT error: fails before any data operation', async () => {
+      const fs = makeFsPort({
+        readIndexesSidecar: async () => {
+          throw new Error('EACCES: permission denied');
+        },
+      });
+      const dialog = makeDialogPort();
+      const mongo = makeMongoPort();
+      const { emits, emit } = makeEmitSpy();
+      const registry = createOperationRegistry({ mongo, fs, dialog, emit });
+
+      registry.start(importParams({ clearFirst: true }));
+      const terminal = await waitForTerminal(emits);
+
+      expect(terminal.status).toBe('failed');
+      expect(terminal.error).toMatch(/EACCES/);
+      expect(mongo.importCollection).not.toHaveBeenCalled();
     });
   });
 

--- a/src/main/operation-registry.ts
+++ b/src/main/operation-registry.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'crypto';
+import { EJSON } from 'bson';
 import type { Readable, Writable } from 'stream';
 import type {
   CollectionInfo,
@@ -9,6 +10,7 @@ import type {
   OperationRecord,
   Result,
 } from '../shared/types';
+import type { IndexSpec } from './index-spec';
 
 export interface MongoServicePort {
   exportCollection(
@@ -27,6 +29,7 @@ export interface MongoServicePort {
     signal: AbortSignal
   ): Promise<Result<{ inserted: number; skipped: number }>>;
   listCollections(dbName: string): Promise<Result<CollectionInfo[]>>;
+  getExportableIndexes(dbName: string, collName: string): Promise<Result<IndexSpec[]>>;
 }
 
 export interface GzipSink {
@@ -44,6 +47,8 @@ export interface FilesystemSinkPort {
   writeGzipSink(filePath: string): GzipSink;
   readGunzipSource(filePath: string): GunzipSource;
   joinExportFilename(dir: string, base: string): string;
+  indexesSidecarPath(dataFilePath: string): string;
+  writeIndexesSidecar(filePath: string, json: string): Promise<void>;
 }
 
 export interface DialogProviderPort {
@@ -165,6 +170,24 @@ export function createOperationRegistry(deps: RegistryDeps): OperationRegistry {
       }
     }
 
+    // After data file is finalized, write the indexes sidecar. Failure here
+    // is non-fatal: data file is valid, so we report success with a warning.
+    let warning: string | undefined;
+    if (!failed) {
+      try {
+        const indexesRes = await deps.mongo.getExportableIndexes(params.db, params.collection);
+        if (!indexesRes.ok) {
+          warning = `Exported data but failed to read indexes: ${indexesRes.error}`;
+        } else {
+          const sidecarPath = deps.fs.indexesSidecarPath(savePath);
+          const json = JSON.stringify(EJSON.serialize(indexesRes.data));
+          await deps.fs.writeIndexesSidecar(sidecarPath, json);
+        }
+      } catch (err) {
+        warning = `Exported data but failed to write indexes sidecar: ${(err as Error).message}`;
+      }
+    }
+
     // Release in-flight BEFORE emitting terminal, so a subscriber that
     // re-starts on terminal doesn't hit a stale guard.
     inFlight.delete(key);
@@ -178,6 +201,7 @@ export function createOperationRegistry(deps: RegistryDeps): OperationRegistry {
       emitUpdate(id, {
         status: 'succeeded',
         result: { kind: 'export-collection', exported, path: savePath },
+        warning,
       });
     }
   };

--- a/src/main/operation-registry.ts
+++ b/src/main/operation-registry.ts
@@ -294,6 +294,7 @@ export function createOperationRegistry(deps: RegistryDeps): OperationRegistry {
     let failed = false;
     let errorMsg: string | undefined;
     let cancelled = false;
+    const sidecarErrorCollections: string[] = [];
 
     for (let i = 0; i < collections.length; i++) {
       if (ac.signal.aborted) {
@@ -345,19 +346,37 @@ export function createOperationRegistry(deps: RegistryDeps): OperationRegistry {
         if (cancelled) break;
         failed = true;
         break;
-      } else {
-        try {
-          await sink.finalize();
-        } catch (err) {
-          await sink.destroy();
-          failed = true;
-          errorMsg = (err as Error).message;
-          break;
+      }
+
+      try {
+        await sink.finalize();
+      } catch (err) {
+        await sink.destroy();
+        failed = true;
+        errorMsg = (err as Error).message;
+        break;
+      }
+
+      // Sidecar write is best-effort per collection. A single bad collection
+      // must not abort a long DB export — accumulate the name and continue.
+      try {
+        const indexesRes = await deps.mongo.getExportableIndexes(params.db, coll.name);
+        if (!indexesRes.ok) {
+          sidecarErrorCollections.push(coll.name);
+        } else {
+          const sidecarPath = deps.fs.indexesSidecarPath(filePath);
+          const json = JSON.stringify(EJSON.serialize(indexesRes.data));
+          await deps.fs.writeIndexesSidecar(sidecarPath, json);
         }
+      } catch {
+        sidecarErrorCollections.push(coll.name);
       }
     }
 
     inFlight.delete(key);
+
+    const warning =
+      sidecarErrorCollections.length > 0 ? `sidecar errors for: ${sidecarErrorCollections.join(', ')}` : undefined;
 
     if (cancelled) {
       emitUpdate(id, {
@@ -371,6 +390,7 @@ export function createOperationRegistry(deps: RegistryDeps): OperationRegistry {
       emitUpdate(id, {
         status: 'succeeded',
         result: { kind: 'export-database', exported: totalExported, folder },
+        warning,
       });
     }
   };

--- a/src/main/operation-registry.ts
+++ b/src/main/operation-registry.ts
@@ -10,7 +10,7 @@ import type {
   OperationRecord,
   Result,
 } from '../shared/types';
-import type { IndexSpec } from './index-spec';
+import { parseAndValidateSidecar, type IndexSpec } from './index-spec';
 
 export interface MongoServicePort {
   exportCollection(
@@ -30,6 +30,12 @@ export interface MongoServicePort {
   ): Promise<Result<{ inserted: number; skipped: number }>>;
   listCollections(dbName: string): Promise<Result<CollectionInfo[]>>;
   getExportableIndexes(dbName: string, collName: string): Promise<Result<IndexSpec[]>>;
+  applyImportedIndexes(
+    dbName: string,
+    collName: string,
+    specs: IndexSpec[],
+    opts: { dropExisting: boolean }
+  ): Promise<Result<undefined>>;
 }
 
 export interface GzipSink {
@@ -49,6 +55,7 @@ export interface FilesystemSinkPort {
   joinExportFilename(dir: string, base: string): string;
   indexesSidecarPath(dataFilePath: string): string;
   writeIndexesSidecar(filePath: string, json: string): Promise<void>;
+  readIndexesSidecar(filePath: string): Promise<string | null>;
 }
 
 export interface DialogProviderPort {
@@ -214,6 +221,22 @@ export function createOperationRegistry(deps: RegistryDeps): OperationRegistry {
   ): Promise<void> => {
     emitUpdate(id, { status: 'running' });
 
+    // Validate sidecar BEFORE any destructive data operation. A bad sidecar
+    // must not cause "Clear collection first" to wipe data and then fail.
+    // Cancellation is not honored during the index-apply phase below.
+    let sidecarSpecs: IndexSpec[] | null = null;
+    try {
+      const sidecarPath = deps.fs.indexesSidecarPath(params.filePath);
+      const raw = await deps.fs.readIndexesSidecar(sidecarPath);
+      if (raw !== null) {
+        sidecarSpecs = parseAndValidateSidecar(raw);
+      }
+    } catch (err) {
+      inFlight.delete(key);
+      emitUpdate(id, { status: 'failed', error: (err as Error).message });
+      return;
+    }
+
     const source = deps.fs.readGunzipSource(params.filePath);
     let failed = false;
     let errorMsg: string | undefined;
@@ -246,19 +269,40 @@ export function createOperationRegistry(deps: RegistryDeps): OperationRegistry {
 
     await source.destroy();
 
-    inFlight.delete(key);
-
     if (failed) {
+      inFlight.delete(key);
       emitUpdate(id, {
         status: cancelled ? 'cancelled' : 'failed',
         error: errorMsg,
       });
-    } else {
-      emitUpdate(id, {
-        status: 'succeeded',
-        result: { kind: 'import-collection', inserted, skipped },
-      });
+      return;
     }
+
+    // Data import succeeded. Apply indexes from sidecar, or surface a warning
+    // if no sidecar was present.
+    let warning: string | undefined;
+    if (sidecarSpecs === null) {
+      warning = 'No indexes were restored (sidecar file not found).';
+    } else {
+      const applyRes = await deps.mongo.applyImportedIndexes(params.db, params.collection, sidecarSpecs, {
+        dropExisting: params.options.clearFirst,
+      });
+      if (!applyRes.ok) {
+        inFlight.delete(key);
+        emitUpdate(id, {
+          status: 'failed',
+          error: `${applyRes.error} (${inserted} docs imported)`,
+        });
+        return;
+      }
+    }
+
+    inFlight.delete(key);
+    emitUpdate(id, {
+      status: 'succeeded',
+      result: { kind: 'import-collection', inserted, skipped },
+      warning,
+    });
   };
 
   const runExportDatabase = async (

--- a/src/renderer/src/components/Sidebar.tsx
+++ b/src/renderer/src/components/Sidebar.tsx
@@ -53,6 +53,7 @@ function CollectionRow({ dbName, coll, isSelected, onSelect }: CollectionRowProp
     const rec = await waitForTerminal(id);
     if (rec.status === 'succeeded' && rec.result?.kind === 'export-collection' && rec.result.path !== null) {
       toast.success(`Exported ${rec.result.exported.toLocaleString()} documents`);
+      if (rec.warning) toast.warning(rec.warning);
     } else if (rec.status === 'failed' || rec.status === 'rejected') {
       toast.error(rec.error ?? 'Export failed');
     }
@@ -301,6 +302,7 @@ function DatabaseRow({
         failed = true;
         break;
       }
+      if (rec.warning) toast.warning(`${file.suggestedName}: ${rec.warning}`);
       totalInserted += rec.result.inserted;
       totalSkipped += rec.result.skipped;
     }
@@ -344,6 +346,7 @@ function DatabaseRow({
       if (rec.result.exported > 0) {
         toast.success(`Exported ${rec.result.exported.toLocaleString()} documents`);
       }
+      if (rec.warning) toast.warning(rec.warning);
     } else if (rec.status === 'cancelled') {
       toast('Export cancelled');
     } else if (rec.status === 'failed' || rec.status === 'rejected') {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -136,6 +136,7 @@ export interface OperationRecord {
   progress: OperationProgress;
   result?: OperationResult;
   error?: string;
+  warning?: string;
 }
 
 export interface McpStatus {


### PR DESCRIPTION
### What does this PR do?

## Problem Statement

When I export a MongoDB collection from mongo-buddy and re-import it (either to restore a backup or seed another environment), I get back the documents but none of the user-defined indexes. I have to remember every index I had — its keys, its options (unique, partial filter, TTL, collation, etc.) — and recreate them by hand. For collections with non-trivial indexing this defeats the purpose of "export/import" as a backup/clone tool: my restored collection is functionally different from the original.

PR #42 added the ability to *see* indexes in the GUI and via MCP, but the export/import pipeline still doesn't carry them.

## Solution

Make collection export/import round-trip indexes alongside data, so an export + import reproduces the original collection's indexes (minus the auto `_id_` index, which Mongo always creates).

Indexes are written to a sidecar file `<base>.indexes.json` next to the existing `<base>.bson.gz`. The data file format is unchanged — old `.bson.gz` exports remain importable (with a non-fatal warning that no indexes were restored).

On import, indexes are recreated *after* documents are loaded. If the user chose "Clear collection first", existing non-`_id_` indexes are dropped before recreation; otherwise indexes whose names already exist on the target are skipped (the rest are created). If any index fails to create, the operation fails with a message that surfaces how many documents were already inserted, so the user knows what state the collection is in.

The same sidecar mechanism applies to the existing "Export Database" flow: each collection in the folder gets its own `.indexes.json`.

### Changes

- [x] #44 Export-collection writes indexes sidecar
- [x] #45 Import-collection restores indexes from sidecar
- [x] #46 Export-database writes per-collection indexes sidecar

### Related issues

Closes #43

### How to test



### Additional notes

Generated by [Ralph Issues](https://github.com/richtabor/agent-skills).